### PR TITLE
Add page IDs

### DIFF
--- a/src/abstract-classes/browser-plugin.js
+++ b/src/abstract-classes/browser-plugin.js
@@ -6,19 +6,21 @@ const { throwImplementationNeeded } = require('./utils');
 
 class BrowserPlugin {
     /**
-     *
-     * @param library {object}
-     * @param options {object}
-     * @param options.launchOptions {object}
+     * @param {object} library
+     * @param {object} [options]
+     * @param {object} [options.launchOptions]
+     * @param {string} [options.proxyUrl]
      */
     constructor(library, options = {}) {
         const {
             launchOptions = {},
+            proxyUrl,
         } = options;
 
         this.name = this.constructor.name;
         this.library = library;
         this.launchOptions = launchOptions;
+        this.proxyUrl = proxyUrl && new URL(proxyUrl).href;
     }
 
     /**
@@ -37,7 +39,7 @@ class BrowserPlugin {
         const {
             id,
             launchOptions = {},
-            proxyUrl,
+            proxyUrl = this.proxyUrl,
         } = options;
 
         return new LaunchContext({

--- a/src/abstract-classes/browser-plugin.js
+++ b/src/abstract-classes/browser-plugin.js
@@ -1,5 +1,7 @@
 const _ = require('lodash');
 const proxyChain = require('proxy-chain');
+const LaunchContext = require('../launch_context');
+const log = require('../logger');
 const { throwImplementationNeeded } = require('./utils');
 
 class BrowserPlugin {
@@ -20,38 +22,48 @@ class BrowserPlugin {
     }
 
     /**
-     * Clones and returns the launchOptions with context.
-     * @param options {object} user provided options to include in the context.
-     * @return {object}
+     * Creates a `LaunchContext` with all the information needed
+     * to launch a browser. Aside from library specific launch options,
+     * it also includes internal properties used by `BrowserPool` for
+     * management of the pool and extra features.
+     *
+     * @param {object} [options]
+     * @param {string} [options.id]
+     * @param {object} [options.launchOptions]
+     * @param {string} [options.proxyUrl]
+     * @return {LaunchContext}
      */
-    createLaunchContext(options) {
-        const launchOptions = _.cloneDeep(this.launchOptions);
+    createLaunchContext(options = {}) {
+        const {
+            id,
+            launchOptions = {},
+            proxyUrl,
+        } = options;
 
-        const launchContext = {
-            launchOptions,
-            ...options,
-        };
-
-        return launchContext;
+        return new LaunchContext({
+            id,
+            launchOptions: _.merge({}, this.launchOptions, launchOptions),
+            browserPlugin: this,
+            proxyUrl,
+        });
     }
 
     /**
+     * Launches the browser using provided launch context.
      *
-     *
-     * @param launchContext {object}
+     * @param {LaunchContext} launchContext
      * @return {Promise<BrowserController>}
      */
     async launch(launchContext) {
         if (launchContext.proxyUrl) {
-            this._addProxyToLaunchOptions(launchContext);
+            await this._addProxyToLaunchOptions(launchContext);
         }
 
         return this._launch(launchContext);
     }
 
     /**
-     *
-     * @param launchContext {launchContext}
+     * @param {LaunchContext} launchContext
      * @return {Promise<void>}
      * @private
      */
@@ -60,8 +72,7 @@ class BrowserPlugin {
     }
 
     /**
-     *
-     * @param launchContext {launchContext}
+     * @param {LaunchContext} launchContext
      * @return {Promise<BrowserController>}
      * @private
      */
@@ -71,8 +82,10 @@ class BrowserPlugin {
 
     /**
      * Starts proxy-chain server - https://www.npmjs.com/package/proxy-chain#anonymizeproxyproxyurl-callback
-     * @param proxyUrl {String} - proxy url with username and password;
-     * @return {Promise<string>} - URL of the anonymization proxy server that needs to be closed after the proxy is not used anymore.
+     * @param {string} proxyUrl
+     *  Proxy URL with username and password.
+     * @return {Promise<string>}
+     *  URL of the anonymization proxy server that needs to be closed after the proxy is not used anymore.
      */
     async _getAnonymizedProxyUrl(proxyUrl) {
         let anonymizedProxyUrl;
@@ -88,12 +101,15 @@ class BrowserPlugin {
 
     /**
      *
-     * @param proxyUrl {string} - anonymized proxy url.
+     * @param {string} proxyUrl
+     *  Anonymized proxy URL of a running proxy server.
      * @return {Promise<any>}
      * @private
      */
     async _closeAnonymizedProxy(proxyUrl) {
-        return proxyChain.closeAnonymizedProxy(proxyUrl, true).catch(); // Nothing to do here really.
+        return proxyChain.closeAnonymizedProxy(proxyUrl, true).catch((err) => {
+            log.debug(`Could not close anonymized proxy server.\nCause:${err.message}`);
+        });
     }
 }
 

--- a/src/browser-pool.js
+++ b/src/browser-pool.js
@@ -93,6 +93,11 @@ class BrowserPool extends EventEmitter {
             id = nanoid(),
             pageOptions,
         } = options;
+
+        if (this.pages.has(id)) {
+            throw new Error(`Page with ID: ${id} already exists.`);
+        }
+
         let browserController = this._pickBrowserWithFreeCapacity();
 
         if (!browserController) browserController = await this._launchBrowser(id);
@@ -132,6 +137,10 @@ class BrowserPool extends EventEmitter {
             launchOptions,
             browserPlugin,
         } = options;
+
+        if (this.pages.has(id)) {
+            throw new Error(`Page with ID: ${id} already exists.`);
+        }
 
         const browserController = await this._launchBrowser(id, { launchOptions, browserPlugin });
         const page = await this._createPageForBrowser(id, browserController, pageOptions);

--- a/src/browser-pool.js
+++ b/src/browser-pool.js
@@ -309,12 +309,12 @@ class BrowserPool extends EventEmitter {
             launchOptions,
         });
 
-        await this._executeHooks(this.preLaunchHooks, launchContext);
+        await this._executeHooks(this.preLaunchHooks, pageId, launchContext);
 
         const browserController = await browserPlugin.launch(launchContext);
         log.debug('Launched new browser.', { id: browserController.id });
 
-        await this._executeHooks(this.postLaunchHooks, browserController);
+        await this._executeHooks(this.postLaunchHooks, pageId, browserController);
         this.emit(BROWSER_LAUNCHED, browserController);
 
         this.activeBrowserControllers.add(browserController);

--- a/src/browser-pool.js
+++ b/src/browser-pool.js
@@ -1,5 +1,6 @@
 const EventEmitter = require('events');
 const ow = require('ow').default;
+const { nanoid } = require('nanoid');
 const log = require('./logger');
 const { addTimeoutToPromise } = require('./utils');
 
@@ -61,6 +62,8 @@ class BrowserPool extends EventEmitter {
         this.prePageCloseHooks = prePageCloseHooks;
         this.postPageCloseHooks = postPageCloseHooks;
 
+        this.pages = new Map();
+        this.pageIds = new WeakMap();
         this.activeBrowserControllers = new Set();
         this.retiredBrowserControllers = new Set();
         this.pageToBrowserController = new WeakMap();
@@ -72,41 +75,126 @@ class BrowserPool extends EventEmitter {
     }
 
     /**
-     * Returns existing pending page or new page.
+     * Opens a new page in one of the running browsers or launches
+     * a new browser and opens a page there, if no browsers are active,
+     * or their page limits have been exceeded.
+     *
+     * @param {object} options
+     * @param {string} [options.id]
+     *  Assign a custom ID to the page. If you don't a random string ID
+     *  will be generated.
+     * @param {object} [options.pageOptions]
+     *  Some libraries (Playwright) allow you to open new pages with specific
+     *  options. Use this property to set those options.
      * @return {Promise<Page>}
      */
     async newPage(options = {}) {
-        const { pageOptions, ...others } = options;
+        const {
+            id = nanoid(),
+            pageOptions,
+        } = options;
         let browserController = this._pickBrowserWithFreeCapacity();
 
-        if (!browserController) browserController = await this._launchBrowser({ ...others });
-        return this._createPageForBrowser(browserController, pageOptions);
+        if (!browserController) browserController = await this._launchBrowser(id);
+        const page = await this._createPageForBrowser(id, browserController, pageOptions);
+        this.pages.set(id, page);
+        this.pageIds.set(page, id);
+        return page;
     }
 
     /**
-     * @param options
+     * Unlike {@link newPage}, `newPageInNewBrowser` always launches a new
+     * browser to open the page in. Use the `launchOptions` option to
+     * configure the new browser.
+     *
+     * @param {object} options
+     * @param {string} [options.id]
+     *  Assign a custom ID to the page. If you don't a random string ID
+     *  will be generated.
+     * @param {object} [options.pageOptions]
+     *  Some libraries (Playwright) allow you to open new pages with specific
+     *  options. Use this property to set those options.
+     * @param {object} [options.launchOptions]
+     *  Options that will be used to launch the new browser.
+     * @param {BrowserPlugin} [options.browserPlugin]
+     *  Provide a plugin to launch the browser. If none is provided,
+     *  one of the pool's available plugins will be used.
+     *
+     *  If you configured `BrowserPool` to rotate multiple libraries,
+     *  such as both Puppeteer and Playwright, you should always set
+     *  the `browserPlugin` when using the `launchOptions` option.
      * @return {Promise<Page>}
      */
     async newPageInNewBrowser(options = {}) {
-        const { pageOptions, ...others } = options;
+        const {
+            id = nanoid(),
+            pageOptions,
+            launchOptions,
+            browserPlugin,
+        } = options;
 
-        const browserController = await this._launchBrowser({ ...others });
-        return this._createPageForBrowser(browserController, pageOptions);
+        const browserController = await this._launchBrowser(id, { launchOptions, browserPlugin });
+        const page = await this._createPageForBrowser(id, browserController, pageOptions);
+        this.pages.set(id, page);
+        return page;
     }
 
     /**
+     * Retrieves a {@link BrowserController} for a given page. This is useful
+     * when you're working only with pages and need to access the browser
+     * manipulation functionality.
+     *
+     * You could access the browser directly from the page,
+     * but that would circumvent `BrowserPool` and most likely
+     * cause weird things to happen, so please always use `BrowserController`
+     * to control your browsers. The function returns `undefined` if the
+     * browser is closed.
      *
      * @param page {Page} - Browser plugin page
-     * @return {BrowserController|undefined}
+     * @return {?BrowserController}
      */
     getBrowserControllerByPage(page) {
         return this.pageToBrowserController.get(page);
     }
 
-    async _createPageForBrowser(browserController, pageOptions) {
+    /**
+     * If you provided a custom ID to one of your pages or saved the
+     * randomly generated one, you can use this function to retrieve
+     * the page. If the page is no longer open, the function will
+     * return `undefined`.
+     *
+     * @param {string} id
+     * @return {?Page}
+     */
+    getPage(id) {
+        return this.pages.get(id);
+    }
+
+    /**
+     * Page IDs are used throughout `BrowserPool` as a method of linking
+     * events. You can use a page ID to track the full lifecycle of the page.
+     * It is created even before a browser is launched and stays with the page
+     * until it's closed.
+     *
+     * @param {Page} page
+     * @return {string}
+     */
+    getPageId(page) {
+        return this.pageIds.get(page);
+    }
+
+    /**
+     * @param {string} pageId
+     * @param {BrowserController} browserController
+     * @param {object} pageOptions
+     * @return {Promise<Page>}
+     * @private
+     */
+    async _createPageForBrowser(pageId, browserController, pageOptions) {
+        await this._executeHooks(this.prePageCreateHooks, pageId, browserController);
+        let page;
         try {
-            await this._executeHooks(this.prePageCreateHooks, browserController);
-            const page = await addTimeoutToPromise(
+            page = await addTimeoutToPromise(
                 browserController.newPage(pageOptions),
                 this.operationTimeoutMillis,
                 'browserController.newPage() timed out.',
@@ -118,15 +206,13 @@ class BrowserPool extends EventEmitter {
             }
 
             this._overridePageClose(page);
-            this.emit(PAGE_CREATED, page); // @TODO: CONSIDER renaming this event.
-            await this._executeHooks(this.postPageCreateHooks, browserController, page); // @TODO: Not sure about the placement of this hooks
-            return page;
         } catch (err) {
             this._retireBrowser(browserController);
-            const betterError = new Error(`browserController.newPage() failed: ${browserController.id}.`);
-            betterError.stack = err.stack;
-            throw betterError;
+            throw new Error(`browserController.newPage() failed: ${browserController.id}\nCause:${err.message}.`);
         }
+        await this._executeHooks(this.postPageCreateHooks, page, browserController);
+        this.emit(PAGE_CREATED, page); // @TODO: CONSIDER renaming this event.
+        return page;
     }
 
     /**
@@ -205,21 +291,31 @@ class BrowserPool extends EventEmitter {
     }
 
     /**
+     * @param {string} pageId
+     * @param {object} [options]
+     * @param {object} [options.launchOptions]
+     * @param {object} [options.browserPlugin]
      * @return {Promise<BrowserController>}
      * @private
      */
-    async _launchBrowser(options) {
-        const browserPlugin = this._pickNewBrowserPluginToLaunch();
-        const launchContext = browserPlugin.createLaunchContext(options);
-        launchContext.browserPlugin = browserPlugin;
+    async _launchBrowser(pageId, options = {}) {
+        const {
+            launchOptions,
+            browserPlugin = this._pickNewBrowserPluginToLaunch(),
+        } = options;
+
+        const launchContext = browserPlugin.createLaunchContext({
+            id: pageId,
+            launchOptions,
+        });
 
         await this._executeHooks(this.preLaunchHooks, launchContext);
 
         const browserController = await browserPlugin.launch(launchContext);
         log.debug('Launched new browser.', { id: browserController.id });
 
-        this.emit(BROWSER_LAUNCHED, browserController);
         await this._executeHooks(this.postLaunchHooks, browserController);
+        this.emit(BROWSER_LAUNCHED, browserController);
 
         this.activeBrowserControllers.add(browserController);
 
@@ -269,20 +365,21 @@ class BrowserPool extends EventEmitter {
         const browserController = this.pageToBrowserController.get(page);
 
         page.close = async (...args) => {
-            await this._executeHooks(this.prePageCloseHooks, browserController, page);
+            await this._executeHooks(this.prePageCloseHooks, page, browserController);
             await originalPageClose.apply(page, args)
                 .catch((err) => {
                     log.debug(`Could not close page.\nCause:${err.message}`, { id: browserController.id });
                 });
-            await this._executeHooks(this.postPageCloseHooks, browserController, page);
-            this.emit(PAGE_CLOSED, page);
+            await this._executeHooks(this.postPageCloseHooks, page, browserController);
+            this.pages.delete(this.getPageId(page));
             this._closeRetiredBrowserWithNoPages(browserController);
+            this.emit(PAGE_CLOSED, page);
         };
     }
 
     /**
      * @param {function[]} hooks
-     * @param {Array} args
+     * @param {...*} args
      * @return {Promise<void>}
      * @private
      */

--- a/src/launch_context.js
+++ b/src/launch_context.js
@@ -1,0 +1,61 @@
+class LaunchContext {
+    /**
+     * @param {object} options
+     * @param {BrowserPlugin} options.browserPlugin
+     * @param {object} options.launchOptions
+     * @param {string} [options.id]
+     * @param {string} [options.proxyUrl]
+     */
+    constructor(options) {
+        const {
+            id,
+            browserPlugin,
+            launchOptions,
+            proxyUrl,
+        } = options;
+
+        this.id = id;
+        this.browserPlugin = browserPlugin;
+        this.launchOptions = launchOptions;
+
+        this._proxyUrl = proxyUrl;
+        this._reservedFieldNames = Reflect.ownKeys(this);
+    }
+
+    /**
+     * Extend the launch context with any extra fields.
+     * This is useful to keep state information relevant
+     * to the browser being launched.
+     *
+     * @param {object} fields
+     */
+    extend(fields) {
+        Object.entries(fields).forEach(([key, value]) => {
+            if (this._reservedFieldNames.includes(key)) {
+                throw new Error(`Cannot extend LaunchContext with key: ${key}, because it's reserved.`);
+            } else {
+                this[key] = value;
+            }
+        });
+    }
+
+    /**
+     * Sets a proxy URL for the browser.
+     * Use `undefined` to unset existing proxy URL.
+     *
+     * @param {?string} url
+     */
+    set proxyUrl(url) {
+        this._proxyUrl = url && new URL(url).href;
+    }
+
+    /**
+     * Returns the proxy URL of the browser.
+     * @return {string}
+     */
+    get proxyUrl() {
+        return this._proxyUrl;
+    }
+}
+
+module.exports = LaunchContext;

--- a/test/browser-pool.test.js
+++ b/test/browser-pool.test.js
@@ -167,8 +167,9 @@ describe('BrowserPool', () => {
                     jest.spyOn(browserPool, '_executeHooks');
 
                     const page = await browserPool.newPage();
+                    const pageId = await browserPool.getPageId(page);
                     const { launchContext } = browserPool.getBrowserControllerByPage(page);
-                    expect(browserPool._executeHooks).toHaveBeenNthCalledWith(1, browserPool.preLaunchHooks, launchContext); // eslint-disable-line
+                    expect(browserPool._executeHooks).toHaveBeenNthCalledWith(1, browserPool.preLaunchHooks, pageId, launchContext); // eslint-disable-line
                 });
             });
 
@@ -179,8 +180,9 @@ describe('BrowserPool', () => {
                     jest.spyOn(browserPool, '_executeHooks');
 
                     const page = await browserPool.newPage();
+                    const pageId = await browserPool.getPageId(page);
                     const browserController = browserPool.getBrowserControllerByPage(page);
-                expect(browserPool._executeHooks).toHaveBeenNthCalledWith(2, browserPool.postLaunchHooks, browserController); // eslint-disable-line
+                expect(browserPool._executeHooks).toHaveBeenNthCalledWith(2, browserPool.postLaunchHooks, pageId, browserController); // eslint-disable-line
                 });
             });
 

--- a/test/browser-pool.test.js
+++ b/test/browser-pool.test.js
@@ -16,6 +16,7 @@ describe('BrowserPool', () => {
     let browserPool;
 
     beforeEach(async () => {
+        jest.clearAllMocks();
         browserPool = new BrowserPool({
             browserPlugins: [puppeteerPlugin],
             killInactiveBrowserAfterSecs: 1,
@@ -190,8 +191,9 @@ describe('BrowserPool', () => {
                     jest.spyOn(browserPool, '_executeHooks');
 
                     const page = await browserPool.newPage();
+                    const pageId = browserPool.getPageId(page);
                     const browserController = browserPool.getBrowserControllerByPage(page);
-                expect(browserPool._executeHooks).toHaveBeenNthCalledWith(3, browserPool.prePageCreateHooks, browserController ); // eslint-disable-line
+                    expect(browserPool._executeHooks).toHaveBeenNthCalledWith(3, browserPool.prePageCreateHooks, pageId, browserController); // eslint-disable-line
                 });
             });
 
@@ -203,7 +205,7 @@ describe('BrowserPool', () => {
 
                     const page = await browserPool.newPage();
                     const browserController = browserPool.getBrowserControllerByPage(page);
-                    expect(browserPool._executeHooks).toHaveBeenNthCalledWith(4, browserPool.postPageCreateHooks, browserController, page ); // eslint-disable-line
+                    expect(browserPool._executeHooks).toHaveBeenNthCalledWith(4, browserPool.postPageCreateHooks, page, browserController); // eslint-disable-line
                 });
             });
 
@@ -217,7 +219,7 @@ describe('BrowserPool', () => {
                     await page.close();
 
                     const browserController = browserPool.getBrowserControllerByPage(page);
-                    expect(browserPool._executeHooks).toHaveBeenNthCalledWith(5, browserPool.prePageCloseHooks, browserController, page ); // eslint-disable-line
+                    expect(browserPool._executeHooks).toHaveBeenNthCalledWith(5, browserPool.prePageCloseHooks, page, browserController); // eslint-disable-line
                 });
             });
 
@@ -231,7 +233,7 @@ describe('BrowserPool', () => {
                     await page.close();
 
                     const browserController = browserPool.getBrowserControllerByPage(page);
-                    expect(browserPool._executeHooks).toHaveBeenNthCalledWith(6, browserPool.postPageCloseHooks, browserController, page ); // eslint-disable-line
+                    expect(browserPool._executeHooks).toHaveBeenNthCalledWith(6, browserPool.postPageCloseHooks, page, browserController); // eslint-disable-line
                 });
             });
         });


### PR DESCRIPTION
Besides the obvious access to individual pages using IDs, page IDs are used to track the chain of execution between individual hooks:

```js
// ID is automatically generated
const page = browserPool.newPage();

// Or it can be set manually
const page = browserPool.newPage({ id: 'some-id' });
```
### In `preLaunchHooks`:
```js
(pageId, launchContext) => {
    launchContext.id === pageId // true
}
```
`launchContext.id` === ID of the page that triggered the launch of new browser. It can also be `undefined`, which means that the browser was launched directly via `plugin.launch()` and an ID was not provided. Browsers launched via `browserPool.newPage()` will always have `launchContext.id` set to `pageId`.

### In `postLaunchHooks`:
```js
(pageId, browserController) => {
    // page is not ready yet
}
```

### In `prePageCreateHooks`:
```js
(pageId, browserController) => {
    // page is not ready yet
}
```

### In `postPageCreateHooks` and further:
```js
(page, browserController) => {
    // page is ready, we can get pageId from browser pool
    const pageId = browserPool.getPageId(page);
}
```