### PR TITLE
added pageOptions to the prePageCreateHook. Persistent context.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.1.0 / 2021/02/04
+====================
+- Added `useIncognitoPages` and `userDataDir` to `LaunchContext`.
+- `PlaywrightPlugin` now launches persistent context by default.
+- Improved `playwright` context customization and management.
+
 1.0.1 / 2021/01/01
 ====================
 - Fixed a bug where `prePageCreateHooks` would get triggered before `postLaunchHooks` in some cases.

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ to hear about your use cases in the [Discussions](https://github.com/apify/brows
   * [Simple configuration](#simple-configuration)
   * [Proxy management](#proxy-management)
   * [Lifecycle management with hooks](#lifecycle-management-with-hooks)
+  * [Manipulating playwright context using `pageOptions` or `launchOptions`](#manipulating-playwright-context-using-pageoptions-or-launchoptions)
   * [Single API for common operations](#single-api-for-common-operations)
   * [Graceful browser closing](#graceful-browser-closing)
   * [(UNSTABLE) Extensibility with plugins](#unstable-extensibility-with-plugins)
@@ -222,6 +223,16 @@ await browserPool.newPage({ id: 'my-page' });
 ```
 
 > See the API Documentation for all hooks and their arguments.
+### Manipulating playwright context using `pageOptions` or `launchOptions`
+Playwright allows customizing multiple browser attributes by browser context.
+You can customize some of them once the context is created, but some need to be customized within its creation.
+This part of the documentation should explain how you can effectively customize the browser context.
+
+First of all, let's take a look at what kind of context strategy you chose. You can choose between two strategies by `useIncognitoPages` `LaunchContext` option.
+
+Suppose you decide to keep `useIncognitoPages` default `false` and create a shared context across all pages launched by one browser. In this case,  you should pass the `contextOptions` as a `launchOptions` since the context is created within the new browser launch. The `launchOptions` corresponds to these [playwright options](https://playwright.dev/docs/api/class-browsertype#browsertypelaunchpersistentcontextuserdatadir-options). As you can see, these options contain not only ordinary playwright launch options but also the context options.
+
+If you set `useIncognitoPages` to `true`, you will create a new context within each new page, which allows you to handle each page its cookies and application data. This approach allows you to pass the context options as `pageOptions` because a new context is created once you create a new page. In this case, the `pageOptions` corresponds to these [playwright options](https://playwright.dev/docs/api/class-browser#browsernewpageoptions).
 
 ### Single API for common operations
 Puppeteer and Playwright handle some things differently. Browser Pool

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "browser-pool",
-	"version": "1.0.2",
+	"version": "1.1.0",
 	"description": "Rotate multiple browsers using popular automation libraries such as Playwright or Puppeteer.",
 	"main": "src/index.js",
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
 		"jest": "^26.6.3",
 		"jsdoc-to-markdown": "^6.0.1",
 		"markdown-toc": "^1.2.0",
-		"playwright": "^1.6.2",
-		"puppeteer": "^5.3.1"
+		"playwright": "^1.8.0",
+		"puppeteer": "^5.5.0"
 	},
 	"scripts": {
-        "build-docs": "npm run build-toc && node docs/build_docs.js",
-        "build-toc": "markdown-toc docs/README.md -i",
+		"build-docs": "npm run build-toc && node docs/build_docs.js",
+		"build-toc": "markdown-toc docs/README.md -i",
 		"start": "node src/main.js",
 		"lint": "./node_modules/.bin/eslint ./src --ext .js,.jsx",
 		"lint:fix": "./node_modules/.bin/eslint ./src --ext .js,.jsx --fix",

--- a/src/abstract-classes/browser-controller.js
+++ b/src/abstract-classes/browser-controller.js
@@ -33,6 +33,7 @@ class BrowserController extends EventEmitter {
         this.browser = undefined;
         this.launchContext = undefined;
         this.isActive = false;
+        this.supportsPageOptions = false;
 
         this.isActivePromise = new Promise((resolve) => {
             this._activate = resolve;

--- a/src/abstract-classes/browser-plugin.js
+++ b/src/abstract-classes/browser-plugin.js
@@ -51,6 +51,11 @@ class BrowserPlugin {
      * @param {string} [options.id]
      * @param {object} [options.launchOptions]
      * @param {string} [options.proxyUrl]
+     * @property {boolean} [useIncognitoPages]
+     *  If set to false pages use share the same browser context.
+     *  If set to true each page uses its own context that is destroyed once the page is closed or crashes.
+     * @property {object} [userDataDir]
+     *  Path to a User Data Directory, which stores browser session data like cookies and local storage.
      * @return {LaunchContext}
      * @ignore
      */
@@ -59,7 +64,8 @@ class BrowserPlugin {
             id,
             launchOptions = {},
             proxyUrl = this.proxyUrl,
-            usePersistentContext,
+            useIncognitoPages,
+            userDataDir,
         } = options;
 
         return new LaunchContext({
@@ -67,7 +73,8 @@ class BrowserPlugin {
             launchOptions: _.merge({}, this.launchOptions, launchOptions),
             browserPlugin: this,
             proxyUrl,
-            usePersistentContext,
+            useIncognitoPages,
+            userDataDir,
         });
     }
 

--- a/src/abstract-classes/browser-plugin.js
+++ b/src/abstract-classes/browser-plugin.js
@@ -59,6 +59,7 @@ class BrowserPlugin {
             id,
             launchOptions = {},
             proxyUrl = this.proxyUrl,
+            usePersistentContext,
         } = options;
 
         return new LaunchContext({
@@ -66,6 +67,7 @@ class BrowserPlugin {
             launchOptions: _.merge({}, this.launchOptions, launchOptions),
             browserPlugin: this,
             proxyUrl,
+            usePersistentContext,
         });
     }
 

--- a/src/browser-controllers/playwright-controller.js
+++ b/src/browser-controllers/playwright-controller.js
@@ -5,6 +5,11 @@ const BrowserController = require('../abstract-classes/browser-controller');
  * @extends BrowserController
  */
 class PlaywrightController extends BrowserController {
+    constructor(options) {
+        super(options);
+        this.supportsPageOptions = true;
+    }
+
     async _newPage(pageOptions) {
         const page = await this.browser.newPage(pageOptions);
 

--- a/src/browser-controllers/playwright-controller.js
+++ b/src/browser-controllers/playwright-controller.js
@@ -6,20 +6,10 @@ const BrowserController = require('../abstract-classes/browser-controller');
  * @extends BrowserController
  */
 class PlaywrightController extends BrowserController {
-    constructor(browserPlugin) {
-        super(browserPlugin);
-
-        this.pageToContext = new WeakMap();
-    }
-
     async _newPage(pageOptions) {
-        const context = await this.browser.newContext();
-        const page = await context.newPage(pageOptions);
-
-        this.pageToContext.set(page, context);
+        const page = await this.browser.newPage(pageOptions);
 
         page.once('close', async () => {
-            await context.close().catch(_.noop);
             this.activePages--;
         });
 
@@ -36,12 +26,12 @@ class PlaywrightController extends BrowserController {
     }
 
     async _getCookies(page) {
-        const context = this.pageToContext.get(page);
+        const context = await page.context();
         return context.cookies();
     }
 
     async _setCookies(page, cookies) {
-        const context = this.pageToContext.get(page);
+        const context = await page.context();
         return context.addCookies(cookies);
     }
 }

--- a/src/browser-controllers/playwright-controller.js
+++ b/src/browser-controllers/playwright-controller.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const BrowserController = require('../abstract-classes/browser-controller');
 
 /**

--- a/src/browser-controllers/playwright-controller.js
+++ b/src/browser-controllers/playwright-controller.js
@@ -25,12 +25,12 @@ class PlaywrightController extends BrowserController {
     }
 
     async _getCookies(page) {
-        const context = await page.context();
+        const context = page.context();
         return context.cookies();
     }
 
     async _setCookies(page, cookies) {
-        const context = await page.context();
+        const context = page.context();
         return context.addCookies(cookies);
     }
 }

--- a/src/browser-controllers/puppeteer-controller.js
+++ b/src/browser-controllers/puppeteer-controller.js
@@ -8,21 +8,22 @@ const PROCESS_KILL_TIMEOUT_MILLIS = 5000;
  * puppeteer
  */
 class PuppeteerController extends BrowserController {
-    async _newPage(pageOptions) {
-        const { usePersistentContext = true } = this.launchContext;
+    async _newPage() {
+        const { useIncognitoPages } = this.launchContext;
         let page;
         let context;
 
-        if (usePersistentContext) {
-            page = await this.browser.newPage(pageOptions);
-        } else {
+        if (useIncognitoPages) {
             context = await this.browser.createIncognitoBrowserContext();
             page = await context.newPage();
+        } else {
+            page = await this.browser.newPage();
         }
 
         page.once('close', () => {
             this.activePages--;
-            if (!usePersistentContext) {
+
+            if (useIncognitoPages) {
                 context.close().catch(_.noop);
             }
         });

--- a/src/browser-plugins/playwright-plugin.js
+++ b/src/browser-plugins/playwright-plugin.js
@@ -11,8 +11,14 @@ class PlaywrightPlugin extends BrowserPlugin {
      * @private
      */
     async _launch(launchContext) {
-        const { launchOptions, anonymizedProxyUrl } = launchContext;
-        const browser = await this.library.launch(launchOptions);
+        const { launchOptions, anonymizedProxyUrl, usePersistentContext = false } = launchContext;
+        let browser;
+
+        if (usePersistentContext) {
+            browser = await this.library.launchPersistentContext('', launchOptions); // @TODO: allow to set the userDataDir
+        } else {
+            browser = await this.library.launch(launchOptions);
+        }
 
         if (anonymizedProxyUrl) {
             browser.once('disconnected', () => {

--- a/src/browser-plugins/playwright-plugin.js
+++ b/src/browser-plugins/playwright-plugin.js
@@ -11,13 +11,18 @@ class PlaywrightPlugin extends BrowserPlugin {
      * @private
      */
     async _launch(launchContext) {
-        const { launchOptions, anonymizedProxyUrl, usePersistentContext = false } = launchContext;
+        const {
+            launchOptions,
+            anonymizedProxyUrl,
+            useIncognitoPages,
+            userDataDir,
+        } = launchContext;
         let browser;
 
-        if (usePersistentContext) {
-            browser = await this.library.launchPersistentContext('', launchOptions); // @TODO: allow to set the userDataDir
-        } else {
+        if (useIncognitoPages) {
             browser = await this.library.launch(launchOptions);
+        } else {
+            browser = await this.library.launchPersistentContext(userDataDir, launchOptions);
         }
 
         if (anonymizedProxyUrl) {

--- a/src/browser-plugins/puppeteer-plugin.js
+++ b/src/browser-plugins/puppeteer-plugin.js
@@ -13,8 +13,18 @@ class PuppeteerPlugin extends BrowserPlugin {
      * @private
      */
     async _launch(launchContext) {
-        const { launchOptions, anonymizedProxyUrl } = launchContext;
-        const browser = await this.library.launch(launchOptions);
+        const {
+            launchOptions,
+            anonymizedProxyUrl,
+            userDataDir,
+        } = launchContext;
+
+        const finalLaunchOptions = {
+            ...launchOptions,
+            userDataDir: launchOptions.userDataDir || userDataDir,
+        };
+
+        const browser = await this.library.launch(finalLaunchOptions);
 
         if (anonymizedProxyUrl) {
             browser.once('disconnected', () => {

--- a/src/browser-pool.js
+++ b/src/browser-pool.js
@@ -102,8 +102,9 @@ const BROWSER_KILLER_INTERVAL_MILLIS = 10 * 1000;
  *  are useful to make dynamic changes to the browser before opening a page.
  *  The hooks are called with two arguments:
  *  `pageId`: `string`, `browserController`: {@link BrowserController} and
- *  `pageOptions`: `object` - by default this is an empty object. This only works if the underlying `BrowserController` supports new page options.
+ *  `pageOptions`: `object|undefined` - This only works if the underlying `BrowserController` supports new page options.
  *  So far, new page options are only supported by `PlaywrightController`.
+ *  If the page options are not supported by `BrowserController` the `pageOptions` argument is `undefined`.
  * @param {function[]} [options.postPageCreateHooks]
  *  Post-page-create hooks are called right after a new page is created
  *  and all internal actions of Browser Pool are completed. This is the
@@ -205,7 +206,7 @@ class BrowserPool extends EventEmitter {
     async newPage(options = {}) {
         const {
             id = nanoid(),
-            pageOptions = {},
+            pageOptions,
             browserPlugin = this._pickBrowserPlugin(),
         } = options;
 
@@ -253,7 +254,7 @@ class BrowserPool extends EventEmitter {
     async newPageInNewBrowser(options = {}) {
         const {
             id = nanoid(),
-            pageOptions = {},
+            pageOptions,
             launchOptions,
             browserPlugin = this._pickBrowserPlugin(),
         } = options;
@@ -352,15 +353,22 @@ class BrowserPool extends EventEmitter {
      * @return {Promise<Page>}
      * @private
      */
-    async _createPageForBrowser(pageId, browserController, pageOptions) {
+    async _createPageForBrowser(pageId, browserController, pageOptions = {}) {
         // TODO This is needed for concurrent newPage calls to wait for the browser launch.
         // It's not ideal though, we need to come up with a better API.
         await browserController.isActivePromise;
-        await this._executeHooks(this.prePageCreateHooks, pageId, browserController, pageOptions);
+
+        let finalPageOptions;
+        if (browserController.supportsPageOptions) {
+            finalPageOptions = pageOptions;
+        }
+
+        await this._executeHooks(this.prePageCreateHooks, pageId, browserController, finalPageOptions);
+
         let page;
         try {
             page = await addTimeoutToPromise(
-                browserController.newPage(pageOptions),
+                browserController.newPage(finalPageOptions),
                 this.operationTimeoutMillis,
                 'browserController.newPage() timed out.',
             );

--- a/src/browser-pool.js
+++ b/src/browser-pool.js
@@ -101,7 +101,9 @@ const BROWSER_KILLER_INTERVAL_MILLIS = 10 * 1000;
  *  Pre-page-create hooks are executed just before a new page is created. They
  *  are useful to make dynamic changes to the browser before opening a page.
  *  The hooks are called with two arguments:
- *  `pageId`: `string`, `browserController`: {@link BrowserController} and `pageOptions`: `object` -  library page creation options.
+ *  `pageId`: `string`, `browserController`: {@link BrowserController} and
+ *  `pageOptions`: `object` - by default this is an empty object. This only works if the underlying `BrowserController` supports new page options.
+ *  So far, new page options are only supported by `PlaywrightController`.
  * @param {function[]} [options.postPageCreateHooks]
  *  Post-page-create hooks are called right after a new page is created
  *  and all internal actions of Browser Pool are completed. This is the

--- a/src/browser-pool.js
+++ b/src/browser-pool.js
@@ -101,7 +101,7 @@ const BROWSER_KILLER_INTERVAL_MILLIS = 10 * 1000;
  *  Pre-page-create hooks are executed just before a new page is created. They
  *  are useful to make dynamic changes to the browser before opening a page.
  *  The hooks are called with two arguments:
- *  `pageId`: `string` and `browserController`: {@link BrowserController}
+ *  `pageId`: `string`, `browserController`: {@link BrowserController} and `pageOptions`: `object` -  library page creation options.
  * @param {function[]} [options.postPageCreateHooks]
  *  Post-page-create hooks are called right after a new page is created
  *  and all internal actions of Browser Pool are completed. This is the
@@ -203,7 +203,7 @@ class BrowserPool extends EventEmitter {
     async newPage(options = {}) {
         const {
             id = nanoid(),
-            pageOptions,
+            pageOptions = {},
             browserPlugin = this._pickBrowserPlugin(),
         } = options;
 
@@ -251,7 +251,7 @@ class BrowserPool extends EventEmitter {
     async newPageInNewBrowser(options = {}) {
         const {
             id = nanoid(),
-            pageOptions,
+            pageOptions = {},
             launchOptions,
             browserPlugin = this._pickBrowserPlugin(),
         } = options;
@@ -354,7 +354,7 @@ class BrowserPool extends EventEmitter {
         // TODO This is needed for concurrent newPage calls to wait for the browser launch.
         // It's not ideal though, we need to come up with a better API.
         await browserController.isActivePromise;
-        await this._executeHooks(this.prePageCreateHooks, pageId, browserController);
+        await this._executeHooks(this.prePageCreateHooks, pageId, browserController, pageOptions);
         let page;
         try {
             page = await addTimeoutToPromise(

--- a/src/launch_context.js
+++ b/src/launch_context.js
@@ -1,3 +1,6 @@
+const path = require('path');
+const os = require('os');
+const { nanoid } = require('nanoid');
 /**
  * `LaunchContext` holds information about the launched browser. It's useful
  * to retrieve the `launchOptions`, the proxy the browser was launched with
@@ -14,9 +17,11 @@
  * @property {object} launchOptions
  *  The actual options the browser was launched with, after changes.
  *  Those changes would be typically made in pre-launch hooks.
- * @property {object} usePersistentContext
- *  If set to true pages use share the same browser context.
- *  If set to false each page uses its own context that is destroyed once the page is closed or crashes.
+ * @property {boolean} [useIncognitoPages=false]
+ *  If set to false pages use share the same browser context.
+ *  If set to true each page uses its own context that is destroyed once the page is closed or crashes.
+ * @property {object} [userDataDir]
+ *  Path to a User Data Directory, which stores browser session data like cookies and local storage.
  * @hideconstructor
  */
 class LaunchContext {
@@ -26,7 +31,8 @@ class LaunchContext {
      * @param {object} options.launchOptions
      * @param {string} [options.id]
      * @param {string} [options.proxyUrl]
-     * @param {boolean} [options.usePersistentContext]
+     * @param {boolean} [options.useIncognitoPages=false]
+     * @param {string} [options.userDataDir]
      */
     constructor(options) {
         const {
@@ -34,13 +40,15 @@ class LaunchContext {
             browserPlugin,
             launchOptions,
             proxyUrl,
-            usePersistentContext,
+            useIncognitoPages = false,
+            userDataDir = path.join(os.tmpdir(), nanoid()),
         } = options;
 
         this.id = id;
         this.browserPlugin = browserPlugin;
         this.launchOptions = launchOptions;
-        this.usePersistentContext = usePersistentContext;
+        this.useIncognitoPages = useIncognitoPages;
+        this.userDataDir = userDataDir;
 
         this._proxyUrl = proxyUrl;
         this._reservedFieldNames = Reflect.ownKeys(this);

--- a/src/launch_context.js
+++ b/src/launch_context.js
@@ -14,6 +14,9 @@
  * @property {object} launchOptions
  *  The actual options the browser was launched with, after changes.
  *  Those changes would be typically made in pre-launch hooks.
+ * @property {object} usePersistentContext
+ *  If set to true pages use share the same browser context.
+ *  If set to false each page uses its own context that is destroyed once the page is closed or crashes.
  * @hideconstructor
  */
 class LaunchContext {
@@ -23,6 +26,7 @@ class LaunchContext {
      * @param {object} options.launchOptions
      * @param {string} [options.id]
      * @param {string} [options.proxyUrl]
+     * @param {boolean} [options.usePersistentContext]
      */
     constructor(options) {
         const {
@@ -30,11 +34,13 @@ class LaunchContext {
             browserPlugin,
             launchOptions,
             proxyUrl,
+            usePersistentContext,
         } = options;
 
         this.id = id;
         this.browserPlugin = browserPlugin;
         this.launchOptions = launchOptions;
+        this.usePersistentContext = usePersistentContext;
 
         this._proxyUrl = proxyUrl;
         this._reservedFieldNames = Reflect.ownKeys(this);

--- a/src/launch_context.js
+++ b/src/launch_context.js
@@ -18,7 +18,7 @@ const { nanoid } = require('nanoid');
  *  The actual options the browser was launched with, after changes.
  *  Those changes would be typically made in pre-launch hooks.
  * @property {boolean} [useIncognitoPages=false]
- *  If set to false pages use share the same browser context.
+ *  By default pages share the same browser context.
  *  If set to true each page uses its own context that is destroyed once the page is closed or crashes.
  * @property {object} [userDataDir]
  *  Path to a User Data Directory, which stores browser session data like cookies and local storage.

--- a/test/browser-plugins/plugins.test.js
+++ b/test/browser-plugins/plugins.test.js
@@ -6,7 +6,6 @@ const PuppeteerController = require('../../src/browser-controllers/puppeteer-con
 
 const PlaywrightPlugin = require('../../src/browser-plugins/playwright-plugin.js');
 const PlaywrightController = require('../../src/browser-controllers/playwright-controller');
-const LaunchContext = require('../../src/launch_context');
 
 const runPluginTest = (Plugin, Controller, library) => {
     const plugin = new Plugin(library);

--- a/test/browser-pool.test.js
+++ b/test/browser-pool.test.js
@@ -263,10 +263,10 @@ describe('BrowserPool', () => {
                     const page = await browserPool.newPage();
                     const pageId = browserPool.getPageId(page);
                     const browserController = browserPool.getBrowserControllerByPage(page);
-                    expect(browserPool._executeHooks).toHaveBeenNthCalledWith(3, browserPool.prePageCreateHooks, pageId, browserController, {}); // eslint-disable-line
+                    expect(browserPool._executeHooks).toHaveBeenNthCalledWith(3, browserPool.prePageCreateHooks, pageId, browserController, browserController.supportsPageOptions? {} : undefined); // eslint-disable-line
                 });
 
-                test('should allow changing pageOptions', async () => {
+                test('should allow changing pageOptions only when supported', async () => {
                     let browserController;
                     let options;
                     const myAsyncHook = (pageId, controller, pageOptions) => {
@@ -276,6 +276,7 @@ describe('BrowserPool', () => {
                         browserController = controller;
                     };
                     browserPool.prePageCreateHooks = [myAsyncHook];
+                    browserPool.browserPlugins = [new PlaywrightPlugin(playwright.chromium)];
                     jest.spyOn(browserPool, '_executeHooks');
 
                     await browserPool.newPage();

--- a/test/browser-pool.test.js
+++ b/test/browser-pool.test.js
@@ -57,7 +57,6 @@ describe('BrowserPool', () => {
         // Basic user facing functionality
         test('should open new page', async () => {
             const page = await browserPool.newPage();
-            const page2 = await browserPool.newPage();
 
             expect(page.goto).toBeDefined();
             expect(page.close).toBeDefined();
@@ -264,7 +263,23 @@ describe('BrowserPool', () => {
                     const page = await browserPool.newPage();
                     const pageId = browserPool.getPageId(page);
                     const browserController = browserPool.getBrowserControllerByPage(page);
-                    expect(browserPool._executeHooks).toHaveBeenNthCalledWith(3, browserPool.prePageCreateHooks, pageId, browserController); // eslint-disable-line
+                    expect(browserPool._executeHooks).toHaveBeenNthCalledWith(3, browserPool.prePageCreateHooks, pageId, browserController, {}); // eslint-disable-line
+                });
+
+                test('should allow changing pageOptions', async () => {
+                    let browserController;
+                    let options;
+                    const myAsyncHook = (pageId, controller, pageOptions) => {
+                        pageOptions.customOption = 'TEST';
+                        options = pageOptions;
+                        jest.spyOn(controller, 'newPage');
+                        browserController = controller;
+                    };
+                    browserPool.prePageCreateHooks = [myAsyncHook];
+                    jest.spyOn(browserPool, '_executeHooks');
+
+                    await browserPool.newPage();
+                    expect(browserController.newPage).toHaveBeenCalledWith(options);
                 });
             });
 


### PR DESCRIPTION
The user data dir problem - `playwright` has a required `userDataDir` parameter that needs to provided in order to launch persistent context see https://playwright.dev/docs/1.7.0/api/class-browsertype#browsertypelaunchpersistentcontextuserdatadir-options. However `puppeteer` has this option in `launchOptions`. 

Possible solutions:
1) add `userDataDir` option to the `LaunchContext` and in the case of puppeteer merge it with the `launchOptions` option.
2) Create a default folder in the project root and use this.