### PR TITLE
fix: errors in launch hooks causing browsers stuck in limbo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.1.2 / 2021/03/18
+====================
+- Fixed an error where chains of errors in `preLaunchHooks` and `postLaunchHooks` would cause browser(controller)s to be stuck in limbo forever.
+
 1.1.1 / 2021/02/25
 ====================
 - Fixed `playwrightPlugin.launch()` returning `BrowserContext` instead of `Browser` when `useIncognitoPages: false` was used.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"lodash": "^4.17.20",
 		"nanoid": "^3.1.16",
 		"ow": "^0.23.0",
-		"proxy-chain": "^0.4.5"
+		"proxy-chain": "^1.0.0"
 	},
 	"devDependencies": {
 		"@apify/eslint-config": "^0.1.0",
@@ -19,7 +19,7 @@
 		"jsdoc-to-markdown": "^6.0.1",
 		"markdown-toc": "^1.2.0",
 		"playwright": "^1.9.1",
-		"puppeteer": "^7.1.0"
+		"puppeteer": "^8.0.0"
 	},
 	"scripts": {
 		"build-docs": "npm run build-toc && node docs/build_docs.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "browser-pool",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"description": "Rotate multiple browsers using popular automation libraries such as Playwright or Puppeteer.",
 	"main": "src/index.js",
 	"dependencies": {

--- a/src/abstract-classes/browser-controller.js
+++ b/src/abstract-classes/browser-controller.js
@@ -84,9 +84,11 @@ class BrowserController extends EventEmitter {
      */
     async close() {
         await this.hasBrowserPromise;
-        await this._close().catch((err) => {
-            log.debug(`Could not close browser.\nCause: ${err.message}`, { id: this.id });
-        });
+        await this._close()
+            .then(() => { this.isActive = false; })
+            .catch((err) => {
+                log.debug(`Could not close browser.\nCause: ${err.message}`, { id: this.id });
+            });
         this.emit(BROWSER_CLOSED, this);
         setTimeout(() => {
             this._kill().catch((err) => {


### PR DESCRIPTION
An error in browser launch would add a browser controller, but it would never get activated. Subsequent `newPage()` calls would try to use this browser, but it would never become available.

I'm merging this fast because I need it to fix SDK issues, but I'm adding reviewers to FYI.