### PR TITLE
chore: update apify-shared

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 		"build-toc": "markdown-toc docs/README.md -i"
 	},
 	"dependencies": {
-		"apify-shared": "^0.7.6",
+		"@apify/log": "^1.0.0",
 		"fs-extra": "^9.1.0",
 		"lodash": "^4.17.21",
 		"nanoid": "^3.1.22",

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,4 +1,4 @@
-const defaultLog = require('apify-shared/log');
+const { default: defaultLog } = require('@apify/log');
 
 const log = defaultLog.child({
     prefix: 'BrowserPool',

--- a/test/browser-plugins/plugins.test.js
+++ b/test/browser-plugins/plugins.test.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const PuppeteerPlugin = require('../../src/puppeteer/puppeteer-plugin');
 const PuppeteerController = require('../../src/puppeteer/puppeteer-controller');
 
-const PlaywrightPlugin = require('../../src/playwright/playwright-plugin.js');
+const PlaywrightPlugin = require('../../src/playwright/playwright-plugin');
 const PlaywrightController = require('../../src/playwright/playwright-controller');
 const Browser = require('../../src/playwright/browser');
 const LaunchContext = require('../../src/launch-context');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,6 @@
 const BrowserPool = require('../src/browser-pool');
 const PuppeteerPlugin = require('../src/puppeteer/puppeteer-plugin');
-const PlaywrightPlugin = require('../src/playwright/playwright-plugin.js');
+const PlaywrightPlugin = require('../src/playwright/playwright-plugin');
 
 const modules = require('../src/index');
 


### PR DESCRIPTION
Updates `apify-shared` to use only the needed packages (`log`).