### PR TITLE
fix: browser profile leak

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
 	},
 	"dependencies": {
 		"@apify/log": "^1.1.1",
-		"fs-extra": "^10.0.0",
 		"lodash.merge": "^4.6.2",
 		"nanoid": "^3.1.25",
 		"ow": "^0.27.0",
@@ -60,6 +59,7 @@
 		"@typescript-eslint/eslint-plugin": "^4.29.1",
 		"@typescript-eslint/parser": "^4.29.1",
 		"eslint": "^7.32.0",
+		"fs-extra": "^10.0.0",
 		"gen-esm-wrapper": "^1.1.2",
 		"jest": "^27.0.6",
 		"jest-circus": "^27.0.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "browser-pool",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"description": "Rotate multiple browsers using popular automation libraries such as Playwright or Puppeteer.",
 	"main": "dist/index.js",
 	"module": "dist/index.mjs",

--- a/src/abstract-classes/browser-plugin.ts
+++ b/src/abstract-classes/browser-plugin.ts
@@ -1,5 +1,4 @@
 import merge from 'lodash.merge';
-import { ensureDir } from 'fs-extra';
 import { log } from '../logger';
 import { LaunchContext, LaunchContextOptions } from '../launch-context';
 import { BrowserController } from './browser-controller';
@@ -143,14 +142,10 @@ export abstract class BrowserPlugin<
     async launch(
         launchContext: LaunchContext<Library, LibraryOptions, LaunchResult, NewPageOptions, NewPageResult> = this.createLaunchContext(),
     ): Promise<LaunchResult> {
-        const { proxyUrl, useIncognitoPages, userDataDir } = launchContext;
+        const { proxyUrl } = launchContext;
 
         if (proxyUrl) {
             await this._addProxyToLaunchOptions(launchContext);
-        }
-
-        if (!useIncognitoPages) {
-            await ensureDir(userDataDir);
         }
 
         return this._launch(launchContext);

--- a/src/launch-context.ts
+++ b/src/launch-context.ts
@@ -1,6 +1,3 @@
-import { join } from 'path';
-import { tmpdir } from 'os';
-import { nanoid } from 'nanoid';
 import type { BrowserPlugin, CommonBrowser, CommonLibrary } from './abstract-classes/browser-plugin';
 import { UnwrapPromise } from './utils';
 
@@ -77,7 +74,7 @@ export class LaunchContext<
             launchOptions,
             proxyUrl,
             useIncognitoPages,
-            userDataDir = join(tmpdir(), nanoid()),
+            userDataDir = '',
         } = options;
 
         this.id = id;

--- a/test/browser-plugins/plugins.test.ts
+++ b/test/browser-plugins/plugins.test.ts
@@ -84,7 +84,6 @@ const runPluginTest = <
             const context = plugin.createLaunchContext();
             browser = await plugin.launch(context as never);
 
-            expect(fs.existsSync(context.userDataDir)).toBeTruthy();
             await browser.close();
         });
 

--- a/test/browser-plugins/plugins.test.ts
+++ b/test/browser-plugins/plugins.test.ts
@@ -1,6 +1,5 @@
 import puppeteer from 'puppeteer';
 import playwright from 'playwright';
-import fs from 'fs';
 
 import { PuppeteerPlugin } from '../../src/puppeteer/puppeteer-plugin';
 import { PuppeteerController } from '../../src/puppeteer/puppeteer-controller';

--- a/test/browser-plugins/plugins.test.ts
+++ b/test/browser-plugins/plugins.test.ts
@@ -75,17 +75,6 @@ const runPluginTest = <
             expect(context.useIncognitoPages).toEqual(desiredObject.useIncognitoPages);
         });
 
-        test('should create userDatadir', async () => {
-            plugin = new Plugin(library as never, {
-                useIncognitoPages: false,
-            });
-
-            const context = plugin.createLaunchContext();
-            browser = await plugin.launch(context as never);
-
-            await browser.close();
-        });
-
         test('should get default launchContext values from plugin options', async () => {
             const proxyUrl = 'http://apify1234@10.10.10.0:8080/';
 


### PR DESCRIPTION
Fixes #32

Tested manually via:

```js
const { BrowserPool, PlaywrightPlugin, PuppeteerPlugin } = require('.');
// const playwright = require('playwright');

const browserPool = new BrowserPool({
    browserPlugins: [new PlaywrightPlugin(require('playwright').chromium)],
});

console.time('x');

// An asynchronous IIFE (immediately invoked function expression)
// allows us to use the 'await' keyword.
(async () => {
    console.timeLog('x', 'before new page');
    // // Launches Chromium with Playwright and returns a Playwright Page.
    const page1 = await browserPool.newPage();
    console.timeLog('x', 'after new page');
    // // You can interact with the page as you're used to.
    // await page1.goto('https://example.com');
    // // When you're done, close the page.
    await page1.close();
    console.timeLog('x', 'after page close');
    // // Opens a second page in the same browser.
    // const page2 = await browserPool.newPage();
    // When everything's finished, tear down the pool.
    await browserPool.destroy();
    console.timeLog('x', 'after pool destroy');

    console.log(process._getActiveHandles().length);
    process.exit();
})();

```