### PR TITLE
fix: playwright proxy-per-page

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
 		"nanoid": "^3.1.25",
 		"ow": "^0.27.0",
 		"p-limit": "^3.1.0",
+		"proxy-chain": "^2.0.0-beta.0",
 		"tiny-typed-emitter": "^2.1.0",
 		"tslib": "^2.3.1"
 	},
@@ -68,7 +69,6 @@
 		"jsdoc-to-markdown": "^7.0.1",
 		"markdown-toc": "^1.2.0",
 		"playwright": "^1.13.1",
-		"proxy-chain": "^2.0.0-beta.0",
 		"puppeteer": "^10.4.0",
 		"rimraf": "^3.0.2",
 		"ts-jest": "^27.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "browser-pool",
-	"version": "3.0.2",
+	"version": "3.0.3",
 	"description": "Rotate multiple browsers using popular automation libraries such as Playwright or Puppeteer.",
     "engines": {
         "node": ">=15.10.0"

--- a/src/playwright/playwright-plugin.ts
+++ b/src/playwright/playwright-plugin.ts
@@ -17,6 +17,9 @@ export class PlaywrightPlugin extends BrowserPlugin<BrowserType, Parameters<Brow
         } = launchContext;
         let browser: PlaywrightBrowser;
 
+        // https://github.com/microsoft/playwright/blob/2e4722d460b5142267e0e506ca7ea9a259556b5f/packages/playwright-core/src/server/browserContext.ts#L423-L427
+        launchOptions!.proxy = { server: 'http://per-context' };
+
         if (useIncognitoPages) {
             browser = await this.library.launch(launchOptions);
         } else {
@@ -34,6 +37,24 @@ export class PlaywrightPlugin extends BrowserPlugin<BrowserType, Parameters<Brow
 
             browser = new PlaywrightBrowserWithPersistentContext({ browserContext, version: this._browserVersion });
         }
+
+        browser = new Proxy(browser, {
+            get: (target, property: keyof typeof browser) => {
+                if (property === 'newPage') {
+                    return (async (pageOptions: Parameters<(typeof browser)['newPage']>[0]) => {
+                        return browser.newPage({
+                            ...pageOptions,
+                            proxy: {
+                                server: '',
+                                ...pageOptions?.proxy,
+                            },
+                        });
+                    });
+                }
+
+                return target[property];
+            },
+        });
 
         return browser;
     }

--- a/src/playwright/playwright-plugin.ts
+++ b/src/playwright/playwright-plugin.ts
@@ -38,7 +38,7 @@ export class PlaywrightPlugin extends BrowserPlugin<BrowserType, Parameters<Brow
             browser = new PlaywrightBrowserWithPersistentContext({ browserContext, version: this._browserVersion });
         }
 
-        browser = new Proxy(browser, {
+        return new Proxy(browser, {
             get: (target, property: keyof typeof browser) => {
                 if (property === 'newPage') {
                     return (async (pageOptions: Parameters<(typeof browser)['newPage']>[0]) => {
@@ -55,8 +55,6 @@ export class PlaywrightPlugin extends BrowserPlugin<BrowserType, Parameters<Brow
                 return target[property];
             },
         });
-
-        return browser;
     }
 
     protected _createController(): BrowserController<BrowserType, Parameters<BrowserType['launch']>[0], PlaywrightBrowser> {

--- a/src/playwright/playwright-plugin.ts
+++ b/src/playwright/playwright-plugin.ts
@@ -21,6 +21,7 @@ export class PlaywrightPlugin extends BrowserPlugin<BrowserType, Parameters<Brow
         // Required for the `proxy` context option to work.
         launchOptions!.proxy = {
             server: await getLocalProxyAddress(),
+            ...launchOptions!.proxy,
         };
 
         if (useIncognitoPages) {

--- a/src/proxy-server.ts
+++ b/src/proxy-server.ts
@@ -1,0 +1,16 @@
+import ProxyChain from 'proxy-chain';
+
+const server = new ProxyChain.Server({
+    port: 0,
+});
+
+server.server.unref();
+
+// https://github.com/microsoft/playwright/blob/2e4722d460b5142267e0e506ca7ea9a259556b5f/packages/playwright-core/src/server/browserContext.ts#L423-L427
+export async function getLocalProxyAddress() {
+    if (!server.server.listening) {
+        await server.listen();
+    }
+
+    return `http://127.0.0.1:${server.port}`;
+}

--- a/src/proxy-server.ts
+++ b/src/proxy-server.ts
@@ -1,6 +1,6 @@
-import ProxyChain from 'proxy-chain';
+import { Server as ProxyChainServer } from 'proxy-chain';
 
-const server = new ProxyChain.Server({
+const server = new ProxyChainServer({
     port: 0,
 });
 

--- a/src/proxy-server.ts
+++ b/src/proxy-server.ts
@@ -6,6 +6,7 @@ const server = new ProxyChainServer({
 
 server.server.unref();
 
+// eslint-disable-next-line max-len
 // https://github.com/microsoft/playwright/blob/2e4722d460b5142267e0e506ca7ea9a259556b5f/packages/playwright-core/src/server/browserContext.ts#L423-L427
 export async function getLocalProxyAddress() {
     if (!server.server.listening) {

--- a/test/browser-plugins/plugins.test.ts
+++ b/test/browser-plugins/plugins.test.ts
@@ -411,9 +411,7 @@ describe('Plugins', () => {
                 const response = await page.goto(`http://127.0.0.1:${(target.address() as AddressInfo).port}`);
                 const text = await response!.text();
 
-                // FAILING. It should give 127.0.0.3 for all platforms.
-                // See https://github.com/puppeteer/puppeteer/issues/7698
-                expect(text).toBe(process.platform === 'win32' ? '127.0.0.1' : '127.0.0.3');
+                expect(text).toBe('127.0.0.3');
 
                 await page.close();
             });

--- a/test/browser-plugins/plugins.test.ts
+++ b/test/browser-plugins/plugins.test.ts
@@ -383,7 +383,7 @@ describe('Plugins', () => {
                 await page.close();
             });
 
-            test('proxy and proxyPassword as newPage options', async () => {
+            test('proxy as newPage option', async () => {
                 const plugin = new PlaywrightPlugin(playwright.chromium);
                 const browserController = new PlaywrightController(plugin);
 

--- a/test/browser-plugins/plugins.test.ts
+++ b/test/browser-plugins/plugins.test.ts
@@ -273,14 +273,18 @@ describe('Plugins', () => {
         test('should pass launch options to browser', async () => {
             const plugin = new PuppeteerPlugin(puppeteer);
 
-            jest.spyOn(plugin.library, 'launch');
-            const launchOptions: Record<string, unknown> = {
-                foo: 'bar',
+            const userAgent = 'HelloWorld';
+
+            const launchOptions = {
+                args: [
+                    `--user-agent=${userAgent}`,
+                ],
             };
+
             const launchContext = plugin.createLaunchContext({ launchOptions });
             browser = await plugin.launch(launchContext);
-            launchOptions.userDataDir = launchContext.userDataDir;
-            expect(plugin.library.launch).toHaveBeenCalledWith(launchOptions);
+
+            expect(await browser.userAgent()).toBe(userAgent);
         });
 
         test('proxyUsername and proxyPassword as newPage options', async () => {
@@ -451,13 +455,26 @@ describe('Plugins', () => {
             test('should pass launch options to browser', async () => {
                 const plugin = new PlaywrightPlugin(playwright[browserName]);
 
-                jest.spyOn(plugin.library, 'launch');
-                const launchOptions: Record<string, unknown> = {
-                    foo: 'bar',
+                const userAgent = 'HelloWorld';
+
+                const launchOptions = {
+                    args: [
+                        `--user-agent=${userAgent}`,
+                    ],
                 };
-                const launchContext = plugin.createLaunchContext({ launchOptions, useIncognitoPages: true });
+
+                const launchContext = plugin.createLaunchContext({ launchOptions });
                 browser = await plugin.launch(launchContext);
-                expect(plugin.library.launch).toHaveBeenCalledWith(launchOptions);
+
+                const page = await browser.newPage();
+
+                try {
+                    const response = await page.goto('https://httpbin.org/user-agent');
+                    const json = await response!.json();
+                    expect(json['user-agent']).toBe(userAgent);
+                } finally {
+                    await page.close();
+                }
             });
 
             describe('Browser', () => {

--- a/test/browser-plugins/plugins.test.ts
+++ b/test/browser-plugins/plugins.test.ts
@@ -455,26 +455,23 @@ describe('Plugins', () => {
             test('should pass launch options to browser', async () => {
                 const plugin = new PlaywrightPlugin(playwright[browserName]);
 
-                const userAgent = 'HelloWorld';
+                let ran = false;
 
                 const launchOptions = {
-                    args: [
-                        `--user-agent=${userAgent}`,
-                    ],
+                    logger: {
+                        isEnabled: () => {
+                            ran = true;
+
+                            return false;
+                        },
+                        log: () => {},
+                    },
                 };
 
                 const launchContext = plugin.createLaunchContext({ launchOptions });
                 browser = await plugin.launch(launchContext);
 
-                const page = await browser.newPage();
-
-                try {
-                    const response = await page.goto('https://httpbin.org/user-agent');
-                    const json = await response!.json();
-                    expect(json['user-agent']).toBe(userAgent);
-                } finally {
-                    await page.close();
-                }
+                expect(ran).toBe(true);
             });
 
             describe('Browser', () => {

--- a/test/browser-plugins/plugins.test.ts
+++ b/test/browser-plugins/plugins.test.ts
@@ -462,6 +462,7 @@ describe('Plugins', () => {
 
                             return false;
                         },
+                        // eslint-disable-next-line @typescript-eslint/no-empty-function
                         log: () => {},
                     },
                 };

--- a/test/browser-pool.test.ts
+++ b/test/browser-pool.test.ts
@@ -427,6 +427,7 @@ describe('BrowserPool', () => {
                                 server: `http://127.0.0.3:${protectedProxy.port}`,
                                 username: 'foo',
                                 password: 'bar',
+                                bypass: '<-loopback>',
                             },
                         };
 
@@ -455,20 +456,24 @@ describe('BrowserPool', () => {
                         ],
                     });
 
-                    const pages = await pool.newPageWithEachPlugin();
-                    for (const page of pages) {
-                        try {
-                            const response = await page.goto(`http://127.0.0.1:${(target.address() as AddressInfo).port}`);
-                            const content = await response!.text();
+                    try {
+                        const pages = await pool.newPageWithEachPlugin();
+                        for (const page of pages) {
+                            try {
+                                const response = await page.goto(`http://127.0.0.1:${(target.address() as AddressInfo).port}`);
+                                const content = await response!.text();
 
-                            // Fails on Windows.
-                            // See https://github.com/puppeteer/puppeteer/issues/7698
-                            if (process.platform !== 'win32') {
-                                expect(content).toBe('127.0.0.3');
+                                // Fails on Windows.
+                                // See https://github.com/puppeteer/puppeteer/issues/7698
+                                if (process.platform !== 'win32') {
+                                    expect(content).toBe('127.0.0.3');
+                                }
+                            } finally {
+                                await page.close();
                             }
-                        } finally {
-                            await page.close();
                         }
+                    } finally {
+                        await pool.destroy();
                     }
                 });
             });

--- a/test/browser-pool.test.ts
+++ b/test/browser-pool.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable dot-notation -- Accessing private properties */
 import { AddressInfo } from 'net';
 import http from 'http';
 import { promisify } from 'util';


### PR DESCRIPTION
It requires a global server, even if all the contexts will use a different one.