### PR TITLE
refactor: use cancellable timeouts via `@apify/timeout`

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -5,7 +5,7 @@ export default async (): Promise<Config.InitialOptions> => ({
     preset: 'ts-jest',
     testEnvironment: 'node',
     testRunner: 'jest-circus/runner',
-    testTimeout: 20_000,
+    testTimeout: 30_000,
     collectCoverage: true,
     collectCoverageFrom: [
         '**/src/**/*.ts',

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 	},
 	"dependencies": {
 		"@apify/log": "^1.1.1",
-        "@apify/timeout": "^0.2.0",
+		"@apify/timeout": "^0.2.0",
 		"fingerprint-generator": "^1.0.0",
 		"fingerprint-injector": "^1.0.0",
 		"lodash.merge": "^4.6.2",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
 	},
 	"dependencies": {
 		"@apify/log": "^1.1.1",
+        "@apify/timeout": "^0.2.0",
 		"fingerprint-generator": "^1.0.0",
 		"fingerprint-injector": "^1.0.0",
 		"lodash.merge": "^4.6.2",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 	},
 	"dependencies": {
 		"@apify/log": "^1.1.1",
-		"@apify/timeout": "^0.2.0",
+		"@apify/timeout": "^0.2.1",
 		"fingerprint-generator": "^1.0.0",
 		"fingerprint-injector": "^1.0.0",
 		"lodash.merge": "^4.6.2",

--- a/src/abstract-classes/browser-controller.ts
+++ b/src/abstract-classes/browser-controller.ts
@@ -1,5 +1,6 @@
 import { nanoid } from 'nanoid';
 import { TypedEmitter } from 'tiny-typed-emitter';
+import { tryCancel } from '@apify/timeout';
 import { BROWSER_CONTROLLER_EVENTS } from '../events';
 import { LaunchContext } from '../launch-context';
 import { log } from '../logger';
@@ -207,7 +208,9 @@ export abstract class BrowserController<
         this.totalPages++;
         await this.isActivePromise;
         const page = await this._newPage(pageOptions);
+        tryCancel();
         this.lastPageOpenedAt = Date.now();
+
         return page;
     }
 

--- a/src/browser-pool.ts
+++ b/src/browser-pool.ts
@@ -588,12 +588,9 @@ export class BrowserPool<
      */
     async closeAllBrowsers(): Promise<void> {
         const controllers = this._getAllBrowserControllers();
-
-        const promises: Promise<void>[] = [];
-
-        controllers.forEach((controller) => {
-            promises.push(controller.close());
-        });
+        const promises = [...controllers]
+            .filter((controller) => controller.isActive)
+            .map((controller) => controller.close());
 
         await Promise.all(promises);
     }

--- a/src/playwright/playwright-controller.ts
+++ b/src/playwright/playwright-controller.ts
@@ -1,4 +1,5 @@
 import type { Browser, BrowserType, Page } from 'playwright';
+import { tryCancel } from '@apify/timeout';
 import { BrowserController, Cookie } from '../abstract-classes/browser-controller';
 
 export class PlaywrightController extends BrowserController<BrowserType, Parameters<BrowserType['launch']>[0], Browser> {
@@ -27,6 +28,7 @@ export class PlaywrightController extends BrowserController<BrowserType, Paramet
         }
 
         const page = await this.browser.newPage(contextOptions);
+        tryCancel();
 
         page.once('close', () => {
             this.activePages--;

--- a/src/puppeteer/puppeteer-controller.ts
+++ b/src/puppeteer/puppeteer-controller.ts
@@ -1,3 +1,4 @@
+import { tryCancel } from '@apify/timeout';
 import type Puppeteer from './puppeteer-proxy-per-page';
 import { BrowserController, Cookie } from '../abstract-classes/browser-controller';
 import { log } from '../logger';
@@ -29,13 +30,16 @@ export class PuppeteerController extends BrowserController<typeof Puppeteer> {
             }
 
             const context = await this.browser.createIncognitoBrowserContext(contextOptions);
+            tryCancel();
             const page = await context.newPage();
+            tryCancel();
 
             if (contextOptions.proxyUsername || contextOptions.proxyPassword) {
                 await page.authenticate({
                     username: contextOptions.proxyUsername ?? '',
                     password: contextOptions.proxyPassword ?? '',
                 });
+                tryCancel();
             }
 
             page.once('close', async () => {
@@ -46,12 +50,14 @@ export class PuppeteerController extends BrowserController<typeof Puppeteer> {
                 } catch (error: any) {
                     log.exception(error, 'Failed to close context.');
                 }
+                tryCancel();
             });
 
             return page;
         }
 
         const page = await this.browser.newPage();
+        tryCancel();
 
         page.once('close', () => {
             this.activePages--;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,20 +1,6 @@
 import type { PlaywrightPlugin, PuppeteerPlugin } from '.';
 import type { BrowserPlugin } from './abstract-classes/browser-plugin';
 
-export function addTimeoutToPromise<T>(promise: Promise<T>, timeoutMillis: number, errorMessage: string): Promise<T> {
-    return new Promise(async (resolve, reject) => { // eslint-disable-line
-        const timeout = setTimeout(() => reject(new Error(errorMessage)), timeoutMillis);
-        try {
-            const data = await promise;
-            resolve(data);
-        } catch (err) {
-            reject(err);
-        } finally {
-            clearTimeout(timeout);
-        }
-    });
-};
-
 export type UnwrapPromise<T> = T extends PromiseLike<infer R> ? UnwrapPromise<R> : T;
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/no-unused-vars

--- a/test/browser-pool.test.ts
+++ b/test/browser-pool.test.ts
@@ -91,10 +91,14 @@ describe('BrowserPool', () => {
         });
 
         test('should allow early aborting in case of outer timeout', async () => {
-            console.log(1);
+            const timeout = browserPool.operationTimeoutMillis;
             browserPool.operationTimeoutMillis = 500;
             // @ts-expect-error mocking private method
             const spy = jest.spyOn(BrowserPool.prototype, '_executeHooks');
+
+            await browserPool.newPage();
+            expect(spy).toBeCalledTimes(4);
+            spy.mockReset();
 
             await expect(addTimeoutToPromise(
                 () => browserPool.newPage(),
@@ -107,7 +111,10 @@ describe('BrowserPool', () => {
             // inside `addTimeoutToPromise()`, this would not work and we would get
             // 4 calls instead of just one.
             expect(spy).toBeCalledTimes(1);
+
             spy.mockRestore();
+            browserPool.operationTimeoutMillis = timeout;
+            browserPool.retireAllBrowsers();
         });
 
         test('proxy sugar syntax', async () => {

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "../tsconfig.json",
 	"compilerOptions": {
-		"rootDir": "./",
+		"rootDir": "../",
 		"noEmit": true,
 		"allowJs": true
 	},


### PR DESCRIPTION
This is needed to deal with the timeouts in SDK. We do call `tryCancel()` even outside of the timeout handler - that is to allow early escape from the SDK functions that use the browser pool (and are wrapped inside `addTimeoutToPromise` call). The `tryCancel()` call outside of such handler is a no-op, so it is safe even if the pool would be used elsewhere.

Related:
https://github.com/apify/apify-js/issues/1102
https://github.com/apify/apify-js/issues/1216