### PR TITLE
fix: remove `tryCancel` call from inside event handler

### DIFF
--- a/src/puppeteer/puppeteer-controller.ts
+++ b/src/puppeteer/puppeteer-controller.ts
@@ -50,7 +50,6 @@ export class PuppeteerController extends BrowserController<typeof Puppeteer> {
                 } catch (error: any) {
                     log.exception(error, 'Failed to close context.');
                 }
-                tryCancel();
             });
 
             return page;


### PR DESCRIPTION
This fixes following error:

```
2022-03-05T07:00:59.212Z   Error: handlePageFunction timed out after 120 seconds.
2022-03-05T07:00:59.213Z       at Timeout._onTimeout (/home/myuser/node_modules/@apify/timeout/index.js:84:74)
2022-03-05T07:00:59.214Z       at listOnTimeout (node:internal/timers:559:17)
2022-03-05T07:00:59.216Z       at processTimers (node:internal/timers:502:7)
2022-03-05T07:00:59.547Z /home/myuser/node_modules/@apify/timeout/index.js:44
2022-03-05T07:00:59.548Z         throw new InternalTimeoutError('Promise handler has been canceled due to a timeout');
2022-03-05T07:00:59.550Z               ^
2022-03-05T07:00:59.551Z
2022-03-05T07:00:59.553Z InternalTimeoutError: Promise handler has been canceled due to a timeout
2022-03-05T07:00:59.554Z     at tryCancel (/home/myuser/node_modules/@apify/timeout/index.js:44:15)
2022-03-05T07:00:59.556Z     at /home/myuser/node_modules/browser-pool/dist/puppeteer/puppeteer-controller.js:48:41
2022-03-05T07:00:59.557Z     at runMicrotasks (<anonymous>)
2022-03-05T07:00:59.558Z     at processTicksAndRejections (node:internal/process/task_queues:96:5)
```