### PR TITLE
feat: tab as a container

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+tab-as-a-container

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
 		"url": "https://github.com/apify/browser-pool/issues"
 	},
 	"files": [
-		"dist"
+		"dist",
+        "tab-as-a-container"
 	],
 	"scripts": {
 		"build": "tsc && node copy-definitions.js",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 	},
 	"files": [
 		"dist",
-        "tab-as-a-container"
+		"tab-as-a-container"
 	],
 	"scripts": {
 		"build": "tsc && node copy-definitions.js",

--- a/src/abstract-classes/browser-plugin.ts
+++ b/src/abstract-classes/browser-plugin.ts
@@ -118,6 +118,7 @@ export abstract class BrowserPlugin<
             proxyUrl = this.proxyUrl,
             useIncognitoPages = this.useIncognitoPages,
             userDataDir = this.userDataDir,
+            experimentalContainers,
         } = options;
 
         return new LaunchContext({
@@ -127,6 +128,7 @@ export abstract class BrowserPlugin<
             proxyUrl,
             useIncognitoPages,
             userDataDir,
+            experimentalContainers,
         });
     }
 

--- a/src/launch-context.ts
+++ b/src/launch-context.ts
@@ -38,6 +38,10 @@ export interface LaunchContextOptions<
      */
     useIncognitoPages?: boolean;
     /**
+     * Like `useIncognitoPages`, but for persistent contexts, so cache is used for faster loading.
+     */
+    experimentalContainers?: boolean;
+    /**
      * Path to a User Data Directory, which stores browser session data like cookies and local storage.
      */
     userDataDir?: string;
@@ -59,6 +63,8 @@ export class LaunchContext<
 
     useIncognitoPages: boolean;
 
+    experimentalContainers: boolean;
+
     userDataDir: string;
 
     private _proxyUrl?: string;
@@ -78,12 +84,14 @@ export class LaunchContext<
             proxyUrl,
             useIncognitoPages,
             userDataDir = '',
+            experimentalContainers,
         } = options;
 
         this.id = id;
         this.browserPlugin = browserPlugin;
         this.launchOptions = launchOptions;
         this.useIncognitoPages = useIncognitoPages ?? false;
+        this.experimentalContainers = experimentalContainers ?? false;
         this.userDataDir = userDataDir;
 
         this._proxyUrl = proxyUrl;

--- a/tab-as-a-container/background.js
+++ b/tab-as-a-container/background.js
@@ -1,0 +1,232 @@
+'use strict';
+
+// We do async work so Playwright needs to know when we are ready.
+let finishLoading;
+const loading = new Promise(resolve => {
+    finishLoading = resolve;
+});
+
+// Otherwise Playwright won't know what's the tabId.
+chrome.webNavigation.onCompleted.addListener(async details => {
+    // Different protocols are required, otherwise `onCompleted` won't be emitted.
+    if (details.url.toLowerCase() === 'data:text/plain,tabid' && details.frameId === 0) {
+        await chrome.tabs.update(details.tabId, {url: 'about:blank#' + encodeURIComponent(JSON.stringify({tabId: details.tabId}))});
+    }
+});
+
+const isFirefox = navigator.userAgent.includes('Firefox');
+
+// TODO: https://developer.mozilla.org/en-US/docs/Web/API/Cookie_Store_API
+
+// Uncomment this line if there's a cookie memory leak:
+// chrome.privacy.network.networkPredictionEnabled.set({value: false});
+
+const translator = new Map();
+const counter = new Map();
+
+const getOpenerId = id => {
+    if (typeof id !== 'number') {
+        throw new Error('Expected `id` to be a number');
+    }
+
+    if (translator.has(id)) {
+        const opener = translator.get(id);
+
+        if (translator.has(opener)) {
+            throw new Error('Opener is not the most ascendent');
+        }
+
+        // console.log(`getopener ${id} -> ${opener}`);
+        return opener;
+    }
+
+    return id;
+};
+
+const getCookieURL = cookie => {
+    const protocol = cookie.secure ? 'https:' : 'http:';
+    const fixedDomain = cookie.domain[0] === '.' ? cookie.domain.slice(1) : cookie.domain;
+    const url = `${protocol}//${fixedDomain}${cookie.path}`;
+
+    return url;
+};
+
+// Rewrite cookies that were programatically set to tabId instead of openerId.
+// This is requried because we cannot reliably get openerId inside Playwright.
+chrome.cookies.onChanged.addListener(async changeInfo => {
+    if (!changeInfo.removed) {
+        const {cookie} = changeInfo;
+
+        const dotIndex = cookie.name.indexOf('.');
+        if (dotIndex === -1) {
+            return;
+        }
+
+        const tabId = Number(cookie.name.slice(0, dotIndex));
+        const realCookieName = cookie.name.slice(dotIndex + 1);
+        const opener = getOpenerId(tabId);
+
+        if (tabId !== opener) {
+            await chrome.cookies.remove({
+                name: cookie.name,
+                url: getCookieURL(cookie),
+                storeId: cookie.storeId,
+            });
+
+            delete cookie.hostOnly;
+            delete cookie.session;
+
+            await chrome.cookies.set({
+                ...cookie,
+                name: `${opener}.${realCookieName}`,
+                url: getCookieURL(cookie),
+            });
+        }
+    }
+});
+
+chrome.webRequest.onBeforeSendHeaders.addListener(
+    details => {
+        for (const header of details.requestHeaders) {
+            if (header.name.toLowerCase() === 'cookie') {
+                const id = `${getOpenerId(details.tabId)}.`;
+
+                const fixedCookies = header.value.split('; ').filter(x => x.startsWith(id)).map(x => x.slice(id.length)).join('; ');
+                header.value = fixedCookies;
+            }
+
+            // Sometimes Chrome makes a request on a ghost tab.
+            // We don't want these in order to prevent cluttering cookies.
+            // Yes, `webNavigation.onComitted` is emitted and `webNavigation.onCreatedNavigationTarget` is not.
+            if (header.name.toLowerCase() === 'purpose' && header.value === 'prefetch' && !(counter.has(details.tabId))) {
+                console.log(details);
+                return {
+                    cancel: true,
+                };
+            }
+        }
+
+        return {
+            requestHeaders: details.requestHeaders.filter(header => header.name.toLowerCase() !== 'cookie' || header.value !== ''),
+        };
+    },
+    {urls: ['<all_urls>']},
+    isFirefox ? ['blocking', 'requestHeaders'] : ['blocking', 'requestHeaders', 'extraHeaders'],
+);
+
+// Firefox Bug: doesn't catch https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/report-uri
+chrome.webRequest.onHeadersReceived.addListener(
+    details => {
+        for (const header of details.responseHeaders) {
+            if (header.name.toLowerCase() === 'set-cookie') {
+                const parts = header.value.split('\n');
+
+                // `details.tabId` === -1 when Chrome is making internal requests, such downloading a service worker.
+
+                const openerId = getOpenerId(details.tabId);
+
+                header.value = parts.map(part => {
+                    const equalsIndex = part.indexOf('=');
+                    if (equalsIndex === -1) {
+                        return `${openerId}.=${part.trimStart()}`;
+                    } else {
+                        return `${openerId}.${part.trimStart()}`;
+                    }
+                }).join('\n');
+            }
+        }
+
+        return {
+            responseHeaders: details.responseHeaders,
+        };
+    },
+    {urls: ['<all_urls>']},
+    isFirefox ? ['blocking', 'responseHeaders'] : ['blocking', 'responseHeaders', 'extraHeaders'],
+);
+
+chrome.tabs.onRemoved.addListener(async tabId => {
+    const opener = getOpenerId(tabId);
+    translator.delete(tabId);
+
+    if (counter.has(opener)) {
+        counter.set(opener, counter.get(opener) - 1);
+
+        if (counter.get(opener) < 1) {
+            counter.delete(opener);
+        } else {
+            return;
+        }
+    }
+
+    const id = `${opener}.`;
+
+    chrome.cookies.getAll({}, async cookies => {
+        await Promise.allSettled(cookies.filter(cookie => cookie.name.startsWith(id)).map(cookie => {
+            return chrome.cookies.remove({
+                name: cookie.name,
+                url: getCookieURL(cookie),
+                storeId: cookie.storeId,
+            });
+        }));
+    });
+});
+
+(async () => {
+    const contentResponse = await fetch(chrome.runtime.getURL('content.js'));
+    const contentText = await contentResponse.text();
+
+    // `tabs.onCreated` doesn't work here when manually creating new tabs,
+    // because the opener is the current tab active.
+    //
+    // This events only fires when the page opens something.
+    chrome.webNavigation.onCreatedNavigationTarget.addListener(details => {
+        translator.set(details.tabId, getOpenerId(details.sourceTabId));
+
+        const opener = getOpenerId(details.tabId);
+
+        if (counter.has(opener)) {
+            counter.set(opener, counter.get(opener) + 1);
+        } else {
+            counter.set(opener, 2); // the current one + opener = 2
+        }
+    });
+
+    chrome.webNavigation.onCommitted.addListener(async details => {
+        if (details.url.startsWith('chrome')) {
+            return;
+        }
+
+        const executeCodeInPageContext = `
+        const script = document.createElement('script');
+        script.textContent = code;
+
+        const destination = document.head ?? document.documentElement;
+
+        if (document instanceof HTMLDocument) {
+            destination.append(script);
+            script.remove();
+        }
+        `;
+
+        // Race condition: website scripts may run first
+        await chrome.tabs.executeScript(details.tabId, {
+            code: `'use strict';
+            (() => {
+                if (window.totallyRandomString) {
+                    return;
+                }
+
+                window.totallyRandomString = true;
+
+                const code = "'use strict'; const tabId = '${getOpenerId(details.tabId)}'; (() => {\\n" + ${JSON.stringify(contentText)} + "\\n})();\\n";
+                ${executeCodeInPageContext}
+            })();
+            `,
+            matchAboutBlank: true,
+            allFrames: true,
+            runAt: 'document_start',
+        });
+    });
+
+    finishLoading();
+})();

--- a/tab-as-a-container/content.js
+++ b/tab-as-a-container/content.js
@@ -366,7 +366,7 @@ try {
         Storage: {
 			value: FakeStorage,
 			configurable: true,
-			enumreable: false,
+			enumerable: false,
 			writable: true,
 		},
 		localStorage: {

--- a/tab-as-a-container/content.js
+++ b/tab-as-a-container/content.js
@@ -1,0 +1,530 @@
+const isFirefox = navigator.userAgent.includes('Firefox');
+const key = `${tabId}.`;
+
+const {
+	String,
+	Array,
+	Set,
+	TypeError,
+	Map,
+	WeakMap,
+	Object,
+	Number,
+	Function,
+	Proxy,
+	IDBFactory,
+	IDBDatabase,
+	BroadcastChannel,
+	Storage,
+	// We don't have to implement StorageEvent because this implementation does not use localStorage at all.
+} = globalThis;
+
+const ObjectDefineProperty = Object.defineProperty;
+const ObjectDefineProperties = Object.defineProperties;
+const ObjectGetOwnPropertyDescriptors = Object.getOwnPropertyDescriptors;
+const ObjectGetPrototypeOf = Object.getPrototypeOf;
+const ObjectGetOwnPropertyDescriptor = Object.getOwnPropertyDescriptor;
+const ObjectCreate = Object.create;
+const ObjectEntries = Object.entries;
+const ReflectGet = Reflect.get;
+const ReflectSet = Reflect.set;
+const ObjectKeys = Object.keys;
+const NumberIsFinite = Number.isFinite;
+const MapIteratorPrototypeNext = (new Map()).keys().next;
+
+const clonePrototype = (from) => {
+	const target = ObjectCreate(null);
+	const prototype = ObjectGetOwnPropertyDescriptors(from.prototype);
+
+	for (const [name, descriptor] of ObjectEntries(prototype)) {
+		target[name] = ObjectCreate(null);
+
+		if ('get' in descriptor) {
+			target[name].get = descriptor.get;
+		}
+
+		if ('set' in descriptor) {
+			target[name].set = descriptor.set;
+		}
+
+		if ('value' in descriptor) {
+			target[name] = descriptor.value;
+		}
+	}
+
+	return target;
+};
+
+const fixStack = (error) => {
+	const lines = StringPrototype.split.call(error.stack, '\n');
+	
+    if (isFirefox) {
+        ArrayPrototype.splice.call(lines, 0, 1);
+    } else {
+        ArrayPrototype.splice.call(lines, 1, 1);
+    }
+
+	error.stack = ArrayPrototype.join.call(lines, '\n');
+
+	return error;
+};
+
+const MapPrototype = clonePrototype(Map);
+const WeakMapPrototype = clonePrototype(WeakMap);
+const ArrayPrototype = clonePrototype(Array);
+const StringPrototype = clonePrototype(String);
+const IDBFactoryPrototype = clonePrototype(IDBFactory);
+const IDBDatabasePrototype = clonePrototype(IDBDatabase);
+const StoragePrototype = clonePrototype(Storage);
+
+const privates = new WeakMap();
+
+let invocable = false;
+
+const FakeStorage = class Storage {
+	constructor(...args) {
+		if (invocable) {
+			throw fixStack(new TypeError('Illegal constructor'));
+		}
+
+		WeakMapPrototype.set.call(privates, this, args[0]);
+	}
+
+	get length() {
+		const priv = WeakMapPrototype.get.call(privates, this);
+		if (!priv) {
+			throw fixStack(new TypeError('Illegal invocation'));
+		}
+
+		const {storage, prefix} = priv;
+		const length = StoragePrototype.length.get.call(storage);
+
+		let fakeLength = 0;
+		for (let i = 0; i < length; i++) {
+			const storageKey = StoragePrototype.key.call(storage, i);
+			if (StringPrototype.startsWith.call(storageKey, prefix)) {
+				fakeLength++;
+			}
+		}
+
+		return fakeLength;
+	}
+
+	clear() {
+		const priv = WeakMapPrototype.get.call(privates, this);
+		if (!priv) {
+			throw fixStack(new TypeError('Illegal invocation'));
+		}
+
+		const {storage, prefix} = priv;
+		const length = StoragePrototype.length.get.call(storage);
+		const keys = [];
+
+		for (let i = 0; i < length; i++) {
+			ArrayPrototype.push.call(keys, StoragePrototype.key.call(storage, i));
+		}
+
+		for (let i = 0; i < length; i++) {
+			const storageKey = keys[i];
+			if (StringPrototype.startsWith.call(storageKey, prefix)) {
+				StoragePrototype.removeItem.call(storage, storageKey);
+			}
+		}
+	}
+
+	key(index) {
+		const priv = WeakMapPrototype.get.call(privates, this);
+		if (!priv) {
+			throw fixStack(new TypeError('Illegal invocation'));
+		}
+
+		if (arguments.length === 0) {
+			throw fixStack(new TypeError(`Failed to execute 'key' on 'Storage': 1 argument required, but only 0 present.`));
+		}
+
+		index = NumberIsFinite(index) ? index : 0;
+
+		const {storage, prefix} = priv;
+		const length = StoragePrototype.length.get.call(storage);
+
+		let fakeLength = 0;
+		for (let i = 0; i < length; i++) {
+			const storageKey = StoragePrototype.key.call(storage, i);
+
+			if (StringPrototype.startsWith.call(storageKey, prefix)) {
+				if (fakeLength === index) {
+					return StringPrototype.slice.call(storageKey, prefix.length);
+				}
+
+				fakeLength++;
+			}
+		}
+
+		return null;
+	}
+
+	getItem(key) {
+		const priv = WeakMapPrototype.get.call(privates, this);
+		if (!priv) {
+			throw fixStack(new TypeError('Illegal invocation'));
+		}
+
+		if (arguments.length === 0) {
+			throw fixStack(new TypeError(`Failed to execute 'getItem' on 'Storage': 1 argument required, but only 0 present.`));
+		}
+
+		return StoragePrototype.getItem.call(priv.storage, priv.prefix + key);
+	}
+
+	removeItem(key) {
+		const priv = WeakMapPrototype.get.call(privates, this);
+		if (!priv) {
+			throw fixStack(new TypeError('Illegal invocation'));
+		}
+
+		if (arguments.length === 0) {
+			throw fixStack(new TypeError(`Failed to execute 'removeItem' on 'Storage': 1 argument required, but only 0 present.`));
+		}
+
+		StoragePrototype.removeItem.call(priv.storage, priv.prefix + key);
+	}
+
+	setItem(key, value) {
+		const priv = WeakMapPrototype.get.call(privates, this);
+		if (!priv) {
+			throw fixStack(new TypeError('Illegal invocation'));
+		}
+
+		if (arguments.length === 0 || arguments.length === 1) {
+			throw fixStack(new TypeError(`Failed to execute 'setItem' on 'Storage': 2 arguments required, but only ${arguments.length} present.`));
+		}
+
+		StoragePrototype.setItem.call(priv.storage, priv.prefix + key, value);
+	}
+};
+
+const FakeStoragePrototype = clonePrototype(FakeStorage);
+
+const createStorage = ({storage, prefix}) => {
+	invocable = false;
+	const fake = new FakeStorage({storage, prefix});
+	invocable = true;
+
+	const proxy = new Proxy(fake, {
+		// Default:
+		// apply: (target, thisArg, args) => {},
+		// construct(target, args) => {},
+		// setPrototypeOf: (target, proto) => {},
+		// getPrototypeOf: (target) => {},
+		defineProperty: (target, key, descriptor) => {
+			if ('set' in descriptor || 'get' in descriptor) {
+				throw fixStack(new TypeError(`Failed to set a named property on 'Storage': Accessor properties are not allowed.`));
+			}
+
+			FakeStoragePrototype.setItem.call(target, key, descriptor.value);
+		},
+		deleteProperty: (target, key) => {
+			if (typeof key === 'symbol') {
+				delete target[key];
+			} else {
+				FakeStoragePrototype.removeItem.call(target, key);
+			}
+
+			return true;
+		},
+		get: (target, key) => {
+			if (typeof key === 'symbol') {
+				return target[key];
+			}
+
+			if (key in target) {
+				return ReflectGet(target, key);
+			}
+
+			return FakeStoragePrototype.getItem.call(target, key) ?? undefined;
+		},
+		set: (target, key, value) => {
+			if (typeof key === 'symbol') {
+				ObjectDefineProperty(target, key, {
+					value,
+					configurable: true,
+					writable: true,
+					enumerable: false,
+				});
+
+				return true;
+			}
+
+			if (key in target) {
+				return ReflectSet(target, key, value);
+			}
+
+			return FakeStoragePrototype.setItem.call(target, key, value) ?? true;
+		},
+		has: (target, key) => {
+			if (key in target) {
+				return true;
+			}
+
+			return FakeStoragePrototype.getItem.call(target, key) !== null;
+		},
+		isExtensible: (target) => {
+			return true;
+		},
+		preventExtensions: (target) => {
+			throw fixStack(new TypeError(`Cannot prevent extensions`));
+		},
+		getOwnPropertyDescriptor: (target, key) => {
+			if (key in target) {
+				return ObjectGetOwnPropertyDescriptor(ObjectGetPrototypeOf(target), key);
+			}
+
+			const value = FakeStoragePrototype.getItem.call(target, key);
+
+			if (value !== null) {
+				return {
+					value,
+					writable: true,
+					enumerable: true,
+					configurable: true,
+				};
+			}
+		},
+		ownKeys: (target) => {
+			const keys = [];
+
+			const {storage, prefix} = WeakMapPrototype.get.call(privates, target);
+			const length = StoragePrototype.length.get.call(storage);
+
+			for (let i = 0; i < length; i++) {
+				const storageKey = StoragePrototype.key.call(storage, i);
+
+				if (StringPrototype.startsWith.call(storageKey, prefix)) {
+					ArrayPrototype.push.call(keys, StringPrototype.slice.call(storageKey, prefix.length));
+				}
+			}
+
+			return [...new Set([...keys, ...ObjectKeys(target)])];
+		},
+	});
+
+	privates.set(proxy, privates.get(fake));
+
+	return proxy;
+};
+
+const toHide = new WeakMap();
+for (const Type of [ Function, Object, Array ]) {
+    const create = (fallback) => function() {
+        if (this instanceof FakeStorage) {
+            return '[object Storage]';
+        }
+
+        if (WeakMapPrototype.has.call(toHide, this)) {
+            return `function ${WeakMapPrototype.get.call(toHide, this)}() { [native code] }`;
+        }
+
+        return fallback.call(this);
+    };
+
+    const toString = create(Type.prototype.toString);
+    const toLocaleString = create(Type.prototype.toLocaleString);
+
+    WeakMapPrototype.set.call(toHide, toString, 'toString');
+    WeakMapPrototype.set.call(toHide, toLocaleString, 'toLocaleString');
+
+    Object.defineProperty(Type.prototype, 'toString', {
+        value: toString,
+    });
+    Object.defineProperty(Type.prototype, 'toLocaleString', {
+        value: toLocaleString,
+    });
+}
+
+// https://stackoverflow.com/q/30481516
+try {
+	// We use sessionStorage as the underlying storage for localStorage.
+	// This way we do not have to worry about clean up.
+    const {sessionStorage} = globalThis;
+
+    const fakeLocalStorage = createStorage({storage: sessionStorage, prefix: 'l.'});
+    const fakeSessionStorage = createStorage({storage: sessionStorage, prefix: 's.'});
+
+    const getLocalStorage = function localStorage() { return fakeLocalStorage; };
+    const getSessionStorage = function sessionStorage() { return fakeSessionStorage; };
+
+    WeakMapPrototype.set.call(toHide, FakeStorage, 'Storage');
+    WeakMapPrototype.set.call(toHide, FakeStoragePrototype.key, 'key');
+    WeakMapPrototype.set.call(toHide, FakeStoragePrototype.getItem, 'getItem');
+    WeakMapPrototype.set.call(toHide, FakeStoragePrototype.setItem, 'setItem');
+    WeakMapPrototype.set.call(toHide, FakeStoragePrototype.removeItem, 'removeItem');
+    WeakMapPrototype.set.call(toHide, FakeStoragePrototype.clear, 'clear');
+    WeakMapPrototype.set.call(toHide, getLocalStorage, 'get localStorage');
+    WeakMapPrototype.set.call(toHide, getSessionStorage, 'get sessionStorage');
+
+    ObjectDefineProperties(window, {
+        Storage: {
+			value: FakeStorage,
+			configurable: true,
+			enumreable: false,
+			writable: true,
+		},
+		localStorage: {
+			configurable: true,
+			enumerable: true,
+			get: getLocalStorage,
+			set: undefined,
+		},
+		sessionStorage: {
+			configurable: true,
+			enumerable: true,
+			get: getSessionStorage,
+			set: undefined,
+		},
+    });
+} catch (error) {
+    console.error(error);
+}
+
+{
+	const { Document } = globalThis;
+
+	const realGetCookie = ObjectGetOwnPropertyDescriptor(Document.prototype, 'cookie').get;
+	const realSetCookie = ObjectGetOwnPropertyDescriptor(Document.prototype, 'cookie').set;
+
+	const getCookie = function cookie() {
+		try {
+			const cookies = StringPrototype.split.call(realGetCookie.call(this), '; ');
+			const filtered = ArrayPrototype.filter.call(cookies, (cookie) => StringPrototype.startsWith.call(cookie, key));
+			const mapped = ArrayPrototype.map.call(filtered, (cookie) => {
+				const result = StringPrototype.slice.call(cookie, key.length);
+
+				if (result[0] === '=') {
+					return StringPrototype.slice.call(result, 1);
+				}
+
+				return result;
+			});
+
+			return ArrayPrototype.join.call(mapped, '; ');
+		} catch (error) {
+			throw fixStack(error);
+		}
+	};
+
+	const setCookie = function cookie(cookieString) {
+		cookieString = StringPrototype.trimStart.call(String(cookieString));
+
+		const delimiterIndex = StringPrototype.indexOf.call(cookieString, ';');
+		const equalsIndex = StringPrototype.indexOf.call(cookieString, '=')
+		if ((equalsIndex === -1) || ((delimiterIndex !== -1) && (equalsIndex > delimiterIndex))) {
+			cookieString = '=' + cookieString;
+		}
+
+		try {
+			realSetCookie.call(this, key + cookieString);
+		} catch (error) {
+			throw fixStack(error);	
+		}
+	};
+
+	WeakMapPrototype.set.call(toHide, getCookie, 'get cookie');
+	WeakMapPrototype.set.call(toHide, setCookie, 'set cookie');
+
+	ObjectDefineProperty(Document.prototype, 'cookie', {
+		configurable: true,
+		enumerable: true,
+		get: getCookie,
+		set: setCookie,
+	});
+};
+
+{
+	const openDatabase = function open(name) {
+		try {
+			return IDBFactoryPrototype.open.call(this, key + name);
+		} catch (error) {
+			throw fixStack(error);
+		}
+	};
+	
+	const deleteDatabase = function deleteDatabase(name) {
+		try {
+			return IDBFactoryPrototype.deleteDatabase.call(this, key + name);
+		} catch (error) {
+			throw fixStack(error);
+		}
+	};
+	
+	const databaseName = function name() {
+		try {
+			return StringPrototype.slice.call(IDBDatabasePrototype.name.get.call(this), key.length);
+		} catch (error) {
+			throw fixStack(error);
+		}
+	};
+	
+	WeakMapPrototype.set.call(toHide, openDatabase, 'open');
+	WeakMapPrototype.set.call(toHide, deleteDatabase, 'deleteDatabase');
+	WeakMapPrototype.set.call(toHide, databaseName, 'get name');
+	
+	ObjectDefineProperties(IDBFactory.prototype, {
+		open: {
+			writable: true,
+			configurable: true,
+			enumerable: true,
+			value: openDatabase,
+		},
+		deleteDatabase: {
+			writable: true,
+			configurable: true,
+			enumerable: true,
+			value: deleteDatabase,
+		},
+		name: {
+			configurable: true,
+			enumerable: true,
+			get: databaseName,
+			set: undefined,
+		},
+	});
+};
+
+{
+	ObjectDefineProperty(window, 'BroadcastChannel', {
+		configurable: true,
+		enumerable: false,
+		writable: true,
+		value: new Proxy(BroadcastChannel, {
+			construct: (Target, name) => {
+				return new Target(key + name);
+			},
+		}),
+	});
+	
+	WeakMapPrototype.set.call(toHide, window.BroadcastChannel, 'BroadcastChannel');
+	
+	const getBroadcastChannelName = ObjectGetOwnPropertyDescriptor(BroadcastChannel.prototype, 'name').get;
+	const broadcastChannelName = function name() {
+		try {
+			const realName = getBroadcastChannelName.call(this);
+	
+			if (StringPrototype.startsWith.call(realName, key)) {
+				return StringPrototype.slice.call(realName, key.length);
+			}
+	
+			return realName;
+		} catch (error) {
+			throw fixStack(error);
+		}
+	};
+	
+	WeakMapPrototype.set.call(toHide, broadcastChannelName, 'get name');
+	
+	ObjectDefineProperty(BroadcastChannel.prototype, 'name', {
+		configurable: true,
+		enumerable: true,
+		get: broadcastChannelName,
+		set: undefined,
+	});	
+};

--- a/tab-as-a-container/manifest.json
+++ b/tab-as-a-container/manifest.json
@@ -1,0 +1,24 @@
+{
+	"manifest_version": 2,
+	"name": "Tab as a Container",
+	"version": "1.0.0",
+	"background": {
+		"scripts": [
+			"background.js"
+		],
+		"persistent": true
+	},
+	"permissions": [
+		"webRequest",
+		"webRequestBlocking",
+		"webNavigation",
+		"tabs",
+		"cookies",
+		"privacy",
+		"<all_urls>"
+	],
+	"web_accessible_resources": [
+		"content.js"
+	],
+	"incognito": "not_allowed"
+}


### PR DESCRIPTION
Not sure why CI fails, I guess unrelated breaking `playwright` change...

```js
'use strict';
const playwright = require('playwright');
const { PlaywrightPlugin } = require('../browser-pool/dist/index');

const plugin = new PlaywrightPlugin(playwright.chromium);

(async () => {
	const launchContext = plugin.createLaunchContext({
		experimentalContainers: true,
		launchOptions: {
			headless: false,
		},
	});

	const browser = await plugin.launch(launchContext);

	const controller = plugin.createController();

	controller.assignBrowser(browser, launchContext);
	controller.activate();

	const pages = await Promise.all([
		controller.newPage(),
		controller.newPage(),
	]);

	await controller.setCookies(pages[0], [
		{
			name: 'foo',
			value: 'bar',
			domain: 'httpbin.org',
			expires: Math.floor(Date.now() / 1000) + 3600,
			secure: true,
			httpOnly: false,
			path: '/',
			sameSite: 'Strict',
		}
	]);

	// console.log(
	// 	await controller.getCookies(pages[0]),
	// 	await controller.getCookies(pages[1]),
	// );

	const responses = await Promise.all([
		pages[0].goto('https://httpbin.org/anything'),
		pages[1].goto('https://httpbin.org/anything'),
	]);

	const jsons = await Promise.all(responses.map(response => response.json()));

	console.log(jsons.map(response => response.headers.Cookie));

	await controller.close();
})();
```

Result:

```js
[ 'foo=bar', undefined ]
```

It works! Headless as well! Draft because I need to put the above into a Jest test yet.